### PR TITLE
Fix PagedResult.Next() returning true if there are 0 results.

### DIFF
--- a/clever.go
+++ b/clever.go
@@ -251,7 +251,7 @@ func (r *PagedResult) Next() bool {
 			break
 		}
 	}
-	return true
+	return len(r.lastData) > 0
 }
 
 func (r *PagedResult) Scan(result interface{}) error {


### PR DESCRIPTION
If the first page has 0 results, PagedResult.Next() still has
a return value of 'true' the first time it's called, but .Scan()
will error if it's called because there are no results.
