### PR TITLE
Fix golint issues

### DIFF
--- a/clever.go
+++ b/clever.go
@@ -110,19 +110,19 @@ type Paging struct {
 // Link represents a stable link for querying the API
 type Link struct {
 	Rel string
-	Uri string
+	URI string
 }
 
 // DistrictResp wraps the response given when the user queries for a District
 type DistrictResp struct {
 	District District `json:"data"`
 	Links    []Link
-	Uri      string
+	URI      string
 }
 
 // District corresponds to the District resource in the Clever data schema: clever.com/schema
 type District struct {
-	Id        string
+	ID        string
 	Name      string
 	MdrNumber string `json:"mdr_number"`
 }
@@ -131,7 +131,7 @@ type District struct {
 type SchoolResp struct {
 	Links  []Link
 	School School `json:"data"`
-	Uri    string
+	URI    string
 }
 
 // School corresponds to the School resource in the Clever data schema: clever.com/schema
@@ -139,23 +139,23 @@ type School struct {
 	Created      string
 	District     string
 	HighGrade    string `json:"high_grade"`
-	Id           string
+	ID           string
 	LastModified string `json:"last_modified"`
 	Location     Location
 	LowGrade     string `json:"low_grade"`
 	Name         string
-	NcesId       string `json:"nces_id"`
+	NcesID       string `json:"nces_id"`
 	Phone        string
 	SchoolNumber string `json:"school_number"`
-	SisId        string `json:"sis_id"`
-	StateId      string `json:"state_id"`
+	SisID        string `json:"sis_id"`
+	StateID      string `json:"state_id"`
 }
 
 // TeacherResp wraps the response given when the user queries for a Teacher
 type TeacherResp struct {
 	Links   []Link
 	Teacher Teacher `json:"data"`
-	Uri     string
+	URI     string
 }
 
 // Teacher corresponds to the Teacher resource in the Clever data schema: clever.com/schema
@@ -163,11 +163,11 @@ type Teacher struct {
 	Created       string
 	District      string
 	Email         string
-	Id            string
+	ID            string
 	LastModified  string `json:"last_modified"`
 	Name          Name
 	School        string
-	SisId         string `json:"sis_id"`
+	SisID         string `json:"sis_id"`
 	TeacherNumber string `json:"teacher_number"`
 	Title         string
 }
@@ -176,7 +176,7 @@ type Teacher struct {
 type StudentResp struct {
 	Links   []Link
 	Student Student `json:"data"`
-	Uri     string
+	URI     string
 }
 
 // Student corresponds to the Student resource in the Clever data schema: clever.com/schema
@@ -189,14 +189,14 @@ type Student struct {
 	Gender            string
 	Grade             string
 	HispanicEthnicity string `json:"hispanic_ethnicity"`
-	Id                string
+	ID                string
 	LastModified      string `json:"last_modified"`
 	Location          Location
 	Name              Name
 	Race              string
 	School            string
-	SisId             string `json:"sis_id"`
-	StateId           string `json:"state_id"`
+	SisID             string `json:"sis_id"`
+	StateID           string `json:"state_id"`
 	StudentNumber     string `json:"student_number"`
 }
 
@@ -204,7 +204,7 @@ type Student struct {
 type SectionResp struct {
 	Links   []Link
 	Section Section `json:"data"`
-	Uri     string
+	URI     string
 }
 
 // Section corresponds to the Section resource in the Clever data schema: clever.com/schema
@@ -214,27 +214,30 @@ type Section struct {
 	Created      string
 	District     string
 	Grade        string
-	Id           string
+	ID           string
 	LastModified string `json:"last_modified"`
 	Name         string
 	School       string
-	SisId        string `json:"sis_id"`
+	SisID        string `json:"sis_id"`
 	Students     []string
 	Subject      string
 	Teacher      string
 	Term
 }
 
+// EventResp represents an HTTP response returning data on one Event.
 type EventResp struct {
 	Links []Link
 	Event Event `json:"data"`
-	Uri   string
+	URI   string
 }
 
+// Event represents a data change on an underlying collection.
+// Example types include students.created and teachers.deleted.
 type Event struct {
 	Type    string
 	Created string
-	Id      string
+	ID      string
 	Data    struct {
 		Object map[string]interface{}
 	}
@@ -363,7 +366,7 @@ func (r *PagedResult) Next() bool {
 	r.nextPagePath = ""
 	for _, link := range resp.Links {
 		if link.Rel == "next" {
-			r.nextPagePath = link.Uri
+			r.nextPagePath = link.URI
 			break
 		}
 	}

--- a/clever_test.go
+++ b/clever_test.go
@@ -36,12 +36,12 @@ func TestQueryDistricts(t *testing.T) {
 	}
 
 	resp := DistrictResp{}
-	if err := clever.Query(fmt.Sprintf("/v1.1/districts/%s", district0.Id), nil, &resp); err != nil {
+	if err := clever.Query(fmt.Sprintf("/v1.1/districts/%s", district0.ID), nil, &resp); err != nil {
 		t.Fatalf("Error retrieving district: %s\n", err)
 	}
 
 	expectedDistrict0 := District{
-		Id:        "51a5a56312ec00cc5100007e",
+		ID:        "51a5a56312ec00cc5100007e",
 		Name:      "test district",
 		MdrNumber: "123",
 	}
@@ -62,7 +62,7 @@ func TestQuerySchools(t *testing.T) {
 	}
 
 	resp := SchoolResp{}
-	if err := clever.Query(fmt.Sprintf("/v1.1/schools/%s", school0.Id), nil, &resp); err != nil {
+	if err := clever.Query(fmt.Sprintf("/v1.1/schools/%s", school0.ID), nil, &resp); err != nil {
 		t.Fatalf("Error retrieving school: %s\n", err)
 	}
 
@@ -70,7 +70,7 @@ func TestQuerySchools(t *testing.T) {
 		Created:      "2012-11-06T00:00:00Z",
 		District:     "51a5a56312ec00cc5100007e",
 		HighGrade:    "8",
-		Id:           "4fee004cca2e43cf27000002",
+		ID:           "4fee004cca2e43cf27000002",
 		LastModified: "2012-11-07T00:44:53.079Z",
 		Location: Location{
 			Address: "42139 Fadel Mountains",
@@ -80,11 +80,11 @@ func TestQuerySchools(t *testing.T) {
 		},
 		LowGrade:     "6",
 		Name:         "Clever Preparatory",
-		NcesId:       "94755881",
+		NcesID:       "94755881",
 		Phone:        "(527) 825-2248",
 		SchoolNumber: "2559",
-		SisId:        "2559",
-		StateId:      "23",
+		SisID:        "2559",
+		StateID:      "23",
 	}
 	if !reflect.DeepEqual(expectedSchool0, school0) {
 		t.Fatalf("School did not match expected.")
@@ -103,7 +103,7 @@ func TestQueryTeachers(t *testing.T) {
 	}
 
 	resp := TeacherResp{}
-	if err := clever.Query(fmt.Sprintf("/v1.1/teachers/%s", teacher0.Id), nil, &resp); err != nil {
+	if err := clever.Query(fmt.Sprintf("/v1.1/teachers/%s", teacher0.ID), nil, &resp); err != nil {
 		t.Fatalf("Error retrieving teachers: %s\n", err)
 	}
 
@@ -111,7 +111,7 @@ func TestQueryTeachers(t *testing.T) {
 		Created:      "2013-05-29T06:51:25.139Z",
 		District:     "51a5a56312ec00cc5100007e",
 		Email:        "t.teacher2@ga4edu.org",
-		Id:           "51a5a56d4867bbdf51053c34",
+		ID:           "51a5a56d4867bbdf51053c34",
 		LastModified: "2013-05-29T06:51:25.145Z",
 		Name: Name{
 			First:  "Test",
@@ -119,7 +119,7 @@ func TestQueryTeachers(t *testing.T) {
 			Last:   "Teacher",
 		},
 		School:        "4fee004cca2e43cf27000002",
-		SisId:         "56",
+		SisID:         "56",
 		TeacherNumber: "100",
 		Title:         "Math Teacher",
 	}
@@ -140,13 +140,13 @@ func TestQueryEvents(t *testing.T) {
 	}
 
 	resp := EventResp{}
-	if err := clever.Query(fmt.Sprintf("/v1.1/events/%s", event.Id), nil, &resp); err != nil {
+	if err := clever.Query(fmt.Sprintf("/v1.1/events/%s", event.ID), nil, &resp); err != nil {
 		t.Fatalf("Error retrieving event: %s\n", err)
 	}
 	expectedEvent := Event{
 		Type:    "teachers.deleted",
 		Created: "2015-07-27T19:38:24.919Z",
-		Id:      "55b688b1cd921d4a081c4ec3",
+		ID:      "55b688b1cd921d4a081c4ec3",
 		Data: struct {
 			Object map[string]interface{}
 		}{
@@ -189,7 +189,7 @@ func TestQueryStudents(t *testing.T) {
 	}
 
 	resp := StudentResp{}
-	if err := clever.Query(fmt.Sprintf("/v1.1/students/%s", student0.Id), nil, &resp); err != nil {
+	if err := clever.Query(fmt.Sprintf("/v1.1/students/%s", student0.ID), nil, &resp); err != nil {
 		t.Fatalf("Error retrieving students: %s\n", err)
 	}
 
@@ -202,8 +202,8 @@ func TestQueryStudents(t *testing.T) {
 		HispanicEthnicity: "N",
 		Race:              "Caucasian",
 		School:            "4fee004cca2e43cf27000002",
-		SisId:             "1",
-		StateId:           "2237504",
+		SisID:             "1",
+		StateID:           "2237504",
 		StudentNumber:     "24772",
 		Location: Location{
 			Address: "",
@@ -219,7 +219,7 @@ func TestQueryStudents(t *testing.T) {
 		LastModified: "2013-05-29T06:51:28.006Z",
 		Created:      "2013-05-29T06:51:27.997Z",
 		Email:        "john.doe@ga4edu.org",
-		Id:           "51a5a56f4867bbdf51054054",
+		ID:           "51a5a56f4867bbdf51054054",
 	}
 	if !reflect.DeepEqual(expectedStudent0, student0) {
 		t.Fatalf("Student did not match expected.")
@@ -238,7 +238,7 @@ func TestQuerySections(t *testing.T) {
 	}
 
 	resp := SectionResp{}
-	if err := clever.Query(fmt.Sprintf("/v1.1/sections/%s", section0.Id), nil, &resp); err != nil {
+	if err := clever.Query(fmt.Sprintf("/v1.1/sections/%s", section0.ID), nil, &resp); err != nil {
 		t.Fatalf("Error retrieving sections: %s\n", err)
 	}
 
@@ -248,11 +248,11 @@ func TestQuerySections(t *testing.T) {
 		Created:      "2013-05-29T06:51:27.997Z",
 		District:     "51a5a56312ec00cc5100007e",
 		Grade:        "K",
-		Id:           "51a5a56f4867bbdf51054054",
+		ID:           "51a5a56f4867bbdf51054054",
 		LastModified: "2013-05-29T06:51:28.006Z",
 		Name:         "test section",
 		School:       "4fee004cca2e43cf27000002",
-		SisId:        "1",
+		SisID:        "1",
 		Students:     []string{"51a5a56f4867bbdf51054054"},
 		Subject:      "math",
 		Teacher:      "51a5a56d4867bbdf51053c34",

--- a/doc.go
+++ b/doc.go
@@ -3,31 +3,31 @@
 //
 // Usage
 //
-//package main
+//			package main
 //
-//import (
-//	"golang.org/x/oauth2"
-//	clevergo "gopkg.in/Clever/clever-go.v1"
-//	"log"
-//)
+//			import (
+//				"golang.org/x/oauth2"
+//				clevergo "gopkg.in/Clever/clever-go.v1"
+//				"log"
+//			)
 //
-//func main() {
-//	t := &oauth.Transport{
-//		Source: oauth.StaticTokenSource(&oauth2.Token{AccessToken: "DEMO_TOKEN"}),
-//	}
-//	client := &http.client{Transport: t}
-//	clever := clevergo.New(client, "https://api.clever.com")
-//	paged := clever.QueryAll("/v1.1/districts", nil)
-//	for paged.Next() {
-//		var district clevergo.District
-//		if err := paged.Scan(&district); err != nil {
-//			log.Fatal(err)
-//		}
-//		log.Println(district)
-//	}
-//	if err := paged.Error(); err != nil {
-//		log.Fatal(err)
-//	}
-//}
+//			func main() {
+//				t := &oauth.Transport{
+//					Source: oauth.StaticTokenSource(&oauth2.Token{AccessToken: "DEMO_TOKEN"}),
+//				}
+//				client := &http.client{Transport: t}
+//				clever := clevergo.New(client, "https://api.clever.com")
+//				paged := clever.QueryAll("/v1.1/districts", nil)
+//				for paged.Next() {
+//					var district clevergo.District
+//					if err := paged.Scan(&district); err != nil {
+//						log.Fatal(err)
+//					}
+//					log.Println(district)
+//				}
+//				if err := paged.Error(); err != nil {
+//					log.Fatal(err)
+//				}
+//			}
 //
 package clever

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -14,9 +14,10 @@ import (
 	"strconv"
 )
 
+// PostHandler is a function that handles POST requests.
 type PostHandler func(*http.Request, map[string]string) error
 
-// Loads a directory with json files representing mock resources. See ./data for an example
+// NewMock loads a directory with json files representing mock resources. See ./data for an example
 func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[string][]string) (*http.Client, string) {
 	router := urlrouter.Router{
 		Routes: []urlrouter.Route{
@@ -26,7 +27,7 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/districts/:id",
-				Dest:    MockResourceId(fmt.Sprintf("%s/districts.json", dir)),
+				Dest:    MockResourceID(fmt.Sprintf("%s/districts.json", dir)),
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/schools",
@@ -34,7 +35,7 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/schools/:id",
-				Dest:    MockResourceId(fmt.Sprintf("%s/schools.json", dir)),
+				Dest:    MockResourceID(fmt.Sprintf("%s/schools.json", dir)),
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/teachers",
@@ -42,7 +43,7 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/teachers/:id",
-				Dest:    MockResourceId(fmt.Sprintf("%s/teachers.json", dir)),
+				Dest:    MockResourceID(fmt.Sprintf("%s/teachers.json", dir)),
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/students",
@@ -50,7 +51,7 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/students/:id",
-				Dest:    MockResourceId(fmt.Sprintf("%s/students.json", dir)),
+				Dest:    MockResourceID(fmt.Sprintf("%s/students.json", dir)),
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/sections",
@@ -58,7 +59,7 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/sections/:id",
-				Dest:    MockResourceId(fmt.Sprintf("%s/sections.json", dir)),
+				Dest:    MockResourceID(fmt.Sprintf("%s/sections.json", dir)),
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/events",
@@ -66,7 +67,7 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 			},
 			urlrouter.Route{
 				PathExp: "/v1.1/events/:id",
-				Dest:    MockResourceId(fmt.Sprintf("%s/events.json", dir)),
+				Dest:    MockResourceID(fmt.Sprintf("%s/events.json", dir)),
 			},
 			urlrouter.Route{
 				PathExp: "/mock/rate/limiter",
@@ -101,6 +102,7 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 	return client, ts.URL
 }
 
+// MockResource returns a response with mock data from a resource file in the data/ directory.
 func MockResource(postHandler PostHandler, filenames ...string) func(http.ResponseWriter, *http.Request, map[string]string) {
 	return func(w http.ResponseWriter, req *http.Request, params map[string]string) {
 		switch req.Method {
@@ -132,7 +134,11 @@ func MockResource(postHandler PostHandler, filenames ...string) func(http.Respon
 	}
 }
 
-func MockResourceId(filename string) func(http.ResponseWriter, *http.Request, map[string]string) {
+// MockResourceID returns data for the document with a specific ID.
+// It takes a filename and reads the corresponding file in data/,
+// then returns the data for the object that has a matching ID,
+// or an error if there is no object in that file with the ID.
+func MockResourceID(filename string) func(http.ResponseWriter, *http.Request, map[string]string) {
 	return func(w http.ResponseWriter, req *http.Request, params map[string]string) {
 		file, err := os.Open(filename)
 		if err != nil {
@@ -159,6 +165,7 @@ func MockResourceId(filename string) func(http.ResponseWriter, *http.Request, ma
 	}
 }
 
+// MockResourceRateLimit sets mock rate-limiting header values on a response.
 func MockResourceRateLimit() func(http.ResponseWriter, *http.Request, map[string]string) {
 	return func(w http.ResponseWriter, req *http.Request, params map[string]string) {
 		const statusTooManyRequests = 429
@@ -174,6 +181,7 @@ func MockResourceRateLimit() func(http.ResponseWriter, *http.Request, map[string
 	}
 }
 
+// MockError returns a mock error response for a request.
 func MockError() func(http.ResponseWriter, *http.Request, map[string]string) {
 	return func(w http.ResponseWriter, req *http.Request, params map[string]string) {
 		http.Error(w, `{"code":1337,"error":"there was an error"}`, 500)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,4 @@
 package clever
 
+// Version is the current Clever API version.
 const Version = "1.4.0"


### PR DESCRIPTION
The only open `golint` issue (at default 0.8 confidence) is

`clever.go:70:6: type name will be used as clever.CleverError by other packages, and that stutters; consider calling this Error`

since I felt `Error` is even less descriptive a name, and I'd rather have one that stutters a little.