### PR TITLE
Move code.google.com/p/goauth2/oauth to golang.org/x/oauth2

### DIFF
--- a/clever_test.go
+++ b/clever_test.go
@@ -1,7 +1,6 @@
 package clever
 
 import (
-	"code.google.com/p/goauth2/oauth"
 	"encoding/json"
 	"fmt"
 	mock "github.com/Clever/clever-go/mock"
@@ -10,10 +9,6 @@ import (
 	"reflect"
 	"testing"
 )
-
-var dummytransport = &oauth.Transport{
-	Token: &oauth.Token{AccessToken: "doesntmatter"},
-}
 
 func TestBasicAuthTransport(t *testing.T) {
 	bat := &BasicAuthTransport{"user", "pass"}

--- a/doc.go
+++ b/doc.go
@@ -3,31 +3,31 @@
 //
 // Usage
 //
-//         package main
+//package main
 //
-//         import (
-//         	"code.google.com/p/goauth2/oauth"
-//         	clevergo "gopkg.in/Clever/clever-go.v1"
-//         	"log"
-//         )
+//import (
+//	"golang.org/x/oauth2"
+//	clevergo "gopkg.in/Clever/clever-go.v1"
+//	"log"
+//)
 //
-//         func main() {
-//         	t := &oauth.Transport{
-//         		Token: &oauth.Token{AccessToken: "DEMO_TOKEN"},
-//         	}
-//         	client := t.Client()
-//         	clever := clevergo.New(client, "https://api.clever.com")
-//         	paged := clever.QueryAll("/v1.1/districts", nil)
-//         	for paged.Next() {
-//         		var district clevergo.District
-//         		if err := paged.Scan(&district); err != nil {
-//         			log.Fatal(err)
-//         		}
-//         		log.Println(district)
-//         	}
-//         	if err := paged.Error(); err != nil {
-//         		log.Fatal(err)
-//         	}
-//         }
+//func main() {
+//	t := &oauth.Transport{
+//		Source: oauth.StaticTokenSource(&oauth2.Token{AccessToken: "DEMO_TOKEN"}),
+//	}
+//	client := &http.client{Transport: t}
+//	clever := clevergo.New(client, "https://api.clever.com")
+//	paged := clever.QueryAll("/v1.1/districts", nil)
+//	for paged.Next() {
+//		var district clevergo.District
+//		if err := paged.Scan(&district); err != nil {
+//			log.Fatal(err)
+//		}
+//		log.Println(district)
+//	}
+//	if err := paged.Error(); err != nil {
+//		log.Fatal(err)
+//	}
+//}
 //
 package clever

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,10 +1,10 @@
 package clever
 
 import (
-	"code.google.com/p/goauth2/oauth"
 	"encoding/json"
 	"fmt"
 	"github.com/ant0ine/go-urlrouter"
+	"golang.org/x/oauth2"
 	"io"
 	"log"
 	"net/http"
@@ -93,11 +93,12 @@ func NewMock(postHandler PostHandler, dir string, lastRequestHeader ...*map[stri
 		handler(w, r, params)
 	}))
 
-	t := &oauth.Transport{
-		Token: &oauth.Token{AccessToken: "doesntmatter"},
+	client := &http.Client{
+		Transport: &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "doesntmatter"}),
+		},
 	}
-
-	return t.Client(), ts.URL
+	return client, ts.URL
 }
 
 func MockResource(postHandler PostHandler, filenames ...string) func(http.ResponseWriter, *http.Request, map[string]string) {


### PR DESCRIPTION
Fixes the `warning: code.google.com is shutting down; import
path code.google.com/p/goauth2/oauth will stop working` by
using `golang.org/x/oauth2` (as recommended on Google Code).

This is a cherry-pick of the first commit in https://github.com/Clever/clever-go/pull/28, since the `golint` fixes require a major version bump on `gopkg.in`. /cc @natebrennand 