### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/clever.go
+++ b/clever.go
@@ -64,7 +64,7 @@ type TooManyRequestsError struct {
 	Header http.Header
 }
 
-// TooManyRequestsError creates a TooManyRequestsError
+// Error creates a TooManyRequestsError
 func (err *TooManyRequestsError) Error() string {
 	errString := "Too Many Requests"
 	for bucketIndex, bucketName := range err.Header[http.CanonicalHeaderKey("X-Ratelimit-Bucket")] {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?