### PR TITLE
UM 2966

### DIFF
--- a/client/courses/courses_client.go
+++ b/client/courses/courses_client.go
@@ -46,7 +46,7 @@ type ClientService interface {
 }
 
 /*
-  GetCourse Returns a specific course
+GetCourse Returns a specific course
 */
 func (a *Client) GetCourse(params *GetCourseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetCourseOK, error) {
 	// TODO: Validate the params before sending
@@ -85,7 +85,7 @@ func (a *Client) GetCourse(params *GetCourseParams, authInfo runtime.ClientAuthI
 }
 
 /*
-  GetCourses Returns a list of courses
+GetCourses Returns a list of courses
 */
 func (a *Client) GetCourses(params *GetCoursesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetCoursesOK, error) {
 	// TODO: Validate the params before sending
@@ -124,7 +124,7 @@ func (a *Client) GetCourses(params *GetCoursesParams, authInfo runtime.ClientAut
 }
 
 /*
-  GetDistrictForCourse Returns the district for a course
+GetDistrictForCourse Returns the district for a course
 */
 func (a *Client) GetDistrictForCourse(params *GetDistrictForCourseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetDistrictForCourseOK, error) {
 	// TODO: Validate the params before sending
@@ -163,7 +163,7 @@ func (a *Client) GetDistrictForCourse(params *GetDistrictForCourseParams, authIn
 }
 
 /*
-  GetResourcesForCourse Returns the resources for a course
+GetResourcesForCourse Returns the resources for a course
 */
 func (a *Client) GetResourcesForCourse(params *GetResourcesForCourseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetResourcesForCourseOK, error) {
 	// TODO: Validate the params before sending
@@ -202,7 +202,7 @@ func (a *Client) GetResourcesForCourse(params *GetResourcesForCourseParams, auth
 }
 
 /*
-  GetSchoolsForCourse Returns the schools for a course
+GetSchoolsForCourse Returns the schools for a course
 */
 func (a *Client) GetSchoolsForCourse(params *GetSchoolsForCourseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSchoolsForCourseOK, error) {
 	// TODO: Validate the params before sending
@@ -241,7 +241,7 @@ func (a *Client) GetSchoolsForCourse(params *GetSchoolsForCourseParams, authInfo
 }
 
 /*
-  GetSectionsForCourse Returns the sections for a course
+GetSectionsForCourse Returns the sections for a course
 */
 func (a *Client) GetSectionsForCourse(params *GetSectionsForCourseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSectionsForCourseOK, error) {
 	// TODO: Validate the params before sending

--- a/client/courses/get_course_parameters.go
+++ b/client/courses/get_course_parameters.go
@@ -52,10 +52,12 @@ func NewGetCourseParamsWithHTTPClient(client *http.Client) *GetCourseParams {
 	}
 }
 
-/* GetCourseParams contains all the parameters to send to the API endpoint
-   for the get course operation.
+/*
+GetCourseParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get course operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCourseParams struct {
 

--- a/client/courses/get_course_responses.go
+++ b/client/courses/get_course_responses.go
@@ -36,7 +36,7 @@ func (o *GetCourseReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /courses/{id}] getCourse", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetCourseOK() *GetCourseOK {
 	return &GetCourseOK{}
 }
 
-/* GetCourseOK describes a response with status code 200, with default header values.
+/*
+GetCourseOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetCourseOK struct {
 	Payload *models.CourseResponse
 }
 
+// IsSuccess returns true when this get course o k response has a 2xx status code
+func (o *GetCourseOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get course o k response has a 3xx status code
+func (o *GetCourseOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get course o k response has a 4xx status code
+func (o *GetCourseOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get course o k response has a 5xx status code
+func (o *GetCourseOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get course o k response a status code equal to that given
+func (o *GetCourseOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get course o k response
+func (o *GetCourseOK) Code() int {
+	return 200
+}
+
 func (o *GetCourseOK) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}][%d] getCourseOK  %+v", 200, o.Payload)
 }
+
+func (o *GetCourseOK) String() string {
+	return fmt.Sprintf("[GET /courses/{id}][%d] getCourseOK  %+v", 200, o.Payload)
+}
+
 func (o *GetCourseOK) GetPayload() *models.CourseResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetCourseNotFound() *GetCourseNotFound {
 	return &GetCourseNotFound{}
 }
 
-/* GetCourseNotFound describes a response with status code 404, with default header values.
+/*
+GetCourseNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetCourseNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get course not found response has a 2xx status code
+func (o *GetCourseNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get course not found response has a 3xx status code
+func (o *GetCourseNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get course not found response has a 4xx status code
+func (o *GetCourseNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get course not found response has a 5xx status code
+func (o *GetCourseNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get course not found response a status code equal to that given
+func (o *GetCourseNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get course not found response
+func (o *GetCourseNotFound) Code() int {
+	return 404
+}
+
 func (o *GetCourseNotFound) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}][%d] getCourseNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetCourseNotFound) String() string {
+	return fmt.Sprintf("[GET /courses/{id}][%d] getCourseNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetCourseNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/courses/get_courses_parameters.go
+++ b/client/courses/get_courses_parameters.go
@@ -53,10 +53,12 @@ func NewGetCoursesParamsWithHTTPClient(client *http.Client) *GetCoursesParams {
 	}
 }
 
-/* GetCoursesParams contains all the parameters to send to the API endpoint
-   for the get courses operation.
+/*
+GetCoursesParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get courses operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCoursesParams struct {
 

--- a/client/courses/get_courses_responses.go
+++ b/client/courses/get_courses_responses.go
@@ -30,7 +30,7 @@ func (o *GetCoursesReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /courses] getCourses", response, response.Code())
 	}
 }
 
@@ -39,7 +39,8 @@ func NewGetCoursesOK() *GetCoursesOK {
 	return &GetCoursesOK{}
 }
 
-/* GetCoursesOK describes a response with status code 200, with default header values.
+/*
+GetCoursesOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -47,9 +48,44 @@ type GetCoursesOK struct {
 	Payload *models.CoursesResponse
 }
 
+// IsSuccess returns true when this get courses o k response has a 2xx status code
+func (o *GetCoursesOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get courses o k response has a 3xx status code
+func (o *GetCoursesOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get courses o k response has a 4xx status code
+func (o *GetCoursesOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get courses o k response has a 5xx status code
+func (o *GetCoursesOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get courses o k response a status code equal to that given
+func (o *GetCoursesOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get courses o k response
+func (o *GetCoursesOK) Code() int {
+	return 200
+}
+
 func (o *GetCoursesOK) Error() string {
 	return fmt.Sprintf("[GET /courses][%d] getCoursesOK  %+v", 200, o.Payload)
 }
+
+func (o *GetCoursesOK) String() string {
+	return fmt.Sprintf("[GET /courses][%d] getCoursesOK  %+v", 200, o.Payload)
+}
+
 func (o *GetCoursesOK) GetPayload() *models.CoursesResponse {
 	return o.Payload
 }

--- a/client/courses/get_district_for_course_parameters.go
+++ b/client/courses/get_district_for_course_parameters.go
@@ -52,10 +52,12 @@ func NewGetDistrictForCourseParamsWithHTTPClient(client *http.Client) *GetDistri
 	}
 }
 
-/* GetDistrictForCourseParams contains all the parameters to send to the API endpoint
-   for the get district for course operation.
+/*
+GetDistrictForCourseParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get district for course operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDistrictForCourseParams struct {
 

--- a/client/courses/get_district_for_course_responses.go
+++ b/client/courses/get_district_for_course_responses.go
@@ -36,7 +36,7 @@ func (o *GetDistrictForCourseReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /courses/{id}/district] getDistrictForCourse", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetDistrictForCourseOK() *GetDistrictForCourseOK {
 	return &GetDistrictForCourseOK{}
 }
 
-/* GetDistrictForCourseOK describes a response with status code 200, with default header values.
+/*
+GetDistrictForCourseOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetDistrictForCourseOK struct {
 	Payload *models.DistrictResponse
 }
 
+// IsSuccess returns true when this get district for course o k response has a 2xx status code
+func (o *GetDistrictForCourseOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get district for course o k response has a 3xx status code
+func (o *GetDistrictForCourseOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for course o k response has a 4xx status code
+func (o *GetDistrictForCourseOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get district for course o k response has a 5xx status code
+func (o *GetDistrictForCourseOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for course o k response a status code equal to that given
+func (o *GetDistrictForCourseOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get district for course o k response
+func (o *GetDistrictForCourseOK) Code() int {
+	return 200
+}
+
 func (o *GetDistrictForCourseOK) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/district][%d] getDistrictForCourseOK  %+v", 200, o.Payload)
 }
+
+func (o *GetDistrictForCourseOK) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/district][%d] getDistrictForCourseOK  %+v", 200, o.Payload)
+}
+
 func (o *GetDistrictForCourseOK) GetPayload() *models.DistrictResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetDistrictForCourseNotFound() *GetDistrictForCourseNotFound {
 	return &GetDistrictForCourseNotFound{}
 }
 
-/* GetDistrictForCourseNotFound describes a response with status code 404, with default header values.
+/*
+GetDistrictForCourseNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetDistrictForCourseNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get district for course not found response has a 2xx status code
+func (o *GetDistrictForCourseNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get district for course not found response has a 3xx status code
+func (o *GetDistrictForCourseNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for course not found response has a 4xx status code
+func (o *GetDistrictForCourseNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get district for course not found response has a 5xx status code
+func (o *GetDistrictForCourseNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for course not found response a status code equal to that given
+func (o *GetDistrictForCourseNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get district for course not found response
+func (o *GetDistrictForCourseNotFound) Code() int {
+	return 404
+}
+
 func (o *GetDistrictForCourseNotFound) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/district][%d] getDistrictForCourseNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetDistrictForCourseNotFound) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/district][%d] getDistrictForCourseNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetDistrictForCourseNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/courses/get_resources_for_course_parameters.go
+++ b/client/courses/get_resources_for_course_parameters.go
@@ -53,10 +53,12 @@ func NewGetResourcesForCourseParamsWithHTTPClient(client *http.Client) *GetResou
 	}
 }
 
-/* GetResourcesForCourseParams contains all the parameters to send to the API endpoint
-   for the get resources for course operation.
+/*
+GetResourcesForCourseParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get resources for course operation.
+
+	Typically these are written to a http.Request.
 */
 type GetResourcesForCourseParams struct {
 

--- a/client/courses/get_resources_for_course_responses.go
+++ b/client/courses/get_resources_for_course_responses.go
@@ -36,7 +36,7 @@ func (o *GetResourcesForCourseReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /courses/{id}/resources] getResourcesForCourse", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetResourcesForCourseOK() *GetResourcesForCourseOK {
 	return &GetResourcesForCourseOK{}
 }
 
-/* GetResourcesForCourseOK describes a response with status code 200, with default header values.
+/*
+GetResourcesForCourseOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetResourcesForCourseOK struct {
 	Payload *models.ResourcesResponse
 }
 
+// IsSuccess returns true when this get resources for course o k response has a 2xx status code
+func (o *GetResourcesForCourseOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get resources for course o k response has a 3xx status code
+func (o *GetResourcesForCourseOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resources for course o k response has a 4xx status code
+func (o *GetResourcesForCourseOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get resources for course o k response has a 5xx status code
+func (o *GetResourcesForCourseOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resources for course o k response a status code equal to that given
+func (o *GetResourcesForCourseOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get resources for course o k response
+func (o *GetResourcesForCourseOK) Code() int {
+	return 200
+}
+
 func (o *GetResourcesForCourseOK) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/resources][%d] getResourcesForCourseOK  %+v", 200, o.Payload)
 }
+
+func (o *GetResourcesForCourseOK) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/resources][%d] getResourcesForCourseOK  %+v", 200, o.Payload)
+}
+
 func (o *GetResourcesForCourseOK) GetPayload() *models.ResourcesResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetResourcesForCourseNotFound() *GetResourcesForCourseNotFound {
 	return &GetResourcesForCourseNotFound{}
 }
 
-/* GetResourcesForCourseNotFound describes a response with status code 404, with default header values.
+/*
+GetResourcesForCourseNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetResourcesForCourseNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get resources for course not found response has a 2xx status code
+func (o *GetResourcesForCourseNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get resources for course not found response has a 3xx status code
+func (o *GetResourcesForCourseNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resources for course not found response has a 4xx status code
+func (o *GetResourcesForCourseNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get resources for course not found response has a 5xx status code
+func (o *GetResourcesForCourseNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resources for course not found response a status code equal to that given
+func (o *GetResourcesForCourseNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get resources for course not found response
+func (o *GetResourcesForCourseNotFound) Code() int {
+	return 404
+}
+
 func (o *GetResourcesForCourseNotFound) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/resources][%d] getResourcesForCourseNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetResourcesForCourseNotFound) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/resources][%d] getResourcesForCourseNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetResourcesForCourseNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/courses/get_schools_for_course_parameters.go
+++ b/client/courses/get_schools_for_course_parameters.go
@@ -53,10 +53,12 @@ func NewGetSchoolsForCourseParamsWithHTTPClient(client *http.Client) *GetSchools
 	}
 }
 
-/* GetSchoolsForCourseParams contains all the parameters to send to the API endpoint
-   for the get schools for course operation.
+/*
+GetSchoolsForCourseParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get schools for course operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSchoolsForCourseParams struct {
 

--- a/client/courses/get_schools_for_course_responses.go
+++ b/client/courses/get_schools_for_course_responses.go
@@ -36,7 +36,7 @@ func (o *GetSchoolsForCourseReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /courses/{id}/schools] getSchoolsForCourse", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSchoolsForCourseOK() *GetSchoolsForCourseOK {
 	return &GetSchoolsForCourseOK{}
 }
 
-/* GetSchoolsForCourseOK describes a response with status code 200, with default header values.
+/*
+GetSchoolsForCourseOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSchoolsForCourseOK struct {
 	Payload *models.SchoolsResponse
 }
 
+// IsSuccess returns true when this get schools for course o k response has a 2xx status code
+func (o *GetSchoolsForCourseOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get schools for course o k response has a 3xx status code
+func (o *GetSchoolsForCourseOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get schools for course o k response has a 4xx status code
+func (o *GetSchoolsForCourseOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get schools for course o k response has a 5xx status code
+func (o *GetSchoolsForCourseOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get schools for course o k response a status code equal to that given
+func (o *GetSchoolsForCourseOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get schools for course o k response
+func (o *GetSchoolsForCourseOK) Code() int {
+	return 200
+}
+
 func (o *GetSchoolsForCourseOK) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/schools][%d] getSchoolsForCourseOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSchoolsForCourseOK) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/schools][%d] getSchoolsForCourseOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSchoolsForCourseOK) GetPayload() *models.SchoolsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSchoolsForCourseNotFound() *GetSchoolsForCourseNotFound {
 	return &GetSchoolsForCourseNotFound{}
 }
 
-/* GetSchoolsForCourseNotFound describes a response with status code 404, with default header values.
+/*
+GetSchoolsForCourseNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSchoolsForCourseNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get schools for course not found response has a 2xx status code
+func (o *GetSchoolsForCourseNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get schools for course not found response has a 3xx status code
+func (o *GetSchoolsForCourseNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get schools for course not found response has a 4xx status code
+func (o *GetSchoolsForCourseNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get schools for course not found response has a 5xx status code
+func (o *GetSchoolsForCourseNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get schools for course not found response a status code equal to that given
+func (o *GetSchoolsForCourseNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get schools for course not found response
+func (o *GetSchoolsForCourseNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSchoolsForCourseNotFound) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/schools][%d] getSchoolsForCourseNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSchoolsForCourseNotFound) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/schools][%d] getSchoolsForCourseNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSchoolsForCourseNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/courses/get_sections_for_course_parameters.go
+++ b/client/courses/get_sections_for_course_parameters.go
@@ -53,10 +53,12 @@ func NewGetSectionsForCourseParamsWithHTTPClient(client *http.Client) *GetSectio
 	}
 }
 
-/* GetSectionsForCourseParams contains all the parameters to send to the API endpoint
-   for the get sections for course operation.
+/*
+GetSectionsForCourseParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get sections for course operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSectionsForCourseParams struct {
 

--- a/client/courses/get_sections_for_course_responses.go
+++ b/client/courses/get_sections_for_course_responses.go
@@ -36,7 +36,7 @@ func (o *GetSectionsForCourseReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /courses/{id}/sections] getSectionsForCourse", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSectionsForCourseOK() *GetSectionsForCourseOK {
 	return &GetSectionsForCourseOK{}
 }
 
-/* GetSectionsForCourseOK describes a response with status code 200, with default header values.
+/*
+GetSectionsForCourseOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSectionsForCourseOK struct {
 	Payload *models.SectionsResponse
 }
 
+// IsSuccess returns true when this get sections for course o k response has a 2xx status code
+func (o *GetSectionsForCourseOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get sections for course o k response has a 3xx status code
+func (o *GetSectionsForCourseOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for course o k response has a 4xx status code
+func (o *GetSectionsForCourseOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get sections for course o k response has a 5xx status code
+func (o *GetSectionsForCourseOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for course o k response a status code equal to that given
+func (o *GetSectionsForCourseOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get sections for course o k response
+func (o *GetSectionsForCourseOK) Code() int {
+	return 200
+}
+
 func (o *GetSectionsForCourseOK) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/sections][%d] getSectionsForCourseOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSectionsForCourseOK) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/sections][%d] getSectionsForCourseOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSectionsForCourseOK) GetPayload() *models.SectionsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSectionsForCourseNotFound() *GetSectionsForCourseNotFound {
 	return &GetSectionsForCourseNotFound{}
 }
 
-/* GetSectionsForCourseNotFound describes a response with status code 404, with default header values.
+/*
+GetSectionsForCourseNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSectionsForCourseNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get sections for course not found response has a 2xx status code
+func (o *GetSectionsForCourseNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get sections for course not found response has a 3xx status code
+func (o *GetSectionsForCourseNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for course not found response has a 4xx status code
+func (o *GetSectionsForCourseNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get sections for course not found response has a 5xx status code
+func (o *GetSectionsForCourseNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for course not found response a status code equal to that given
+func (o *GetSectionsForCourseNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get sections for course not found response
+func (o *GetSectionsForCourseNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSectionsForCourseNotFound) Error() string {
 	return fmt.Sprintf("[GET /courses/{id}/sections][%d] getSectionsForCourseNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSectionsForCourseNotFound) String() string {
+	return fmt.Sprintf("[GET /courses/{id}/sections][%d] getSectionsForCourseNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSectionsForCourseNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/districts/districts_client.go
+++ b/client/districts/districts_client.go
@@ -38,7 +38,7 @@ type ClientService interface {
 }
 
 /*
-  GetDistrict Returns a specific district
+GetDistrict Returns a specific district
 */
 func (a *Client) GetDistrict(params *GetDistrictParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetDistrictOK, error) {
 	// TODO: Validate the params before sending
@@ -77,7 +77,7 @@ func (a *Client) GetDistrict(params *GetDistrictParams, authInfo runtime.ClientA
 }
 
 /*
-  GetDistricts Returns a list of districts
+GetDistricts Returns a list of districts
 */
 func (a *Client) GetDistricts(params *GetDistrictsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetDistrictsOK, error) {
 	// TODO: Validate the params before sending

--- a/client/districts/get_district_parameters.go
+++ b/client/districts/get_district_parameters.go
@@ -52,10 +52,12 @@ func NewGetDistrictParamsWithHTTPClient(client *http.Client) *GetDistrictParams 
 	}
 }
 
-/* GetDistrictParams contains all the parameters to send to the API endpoint
-   for the get district operation.
+/*
+GetDistrictParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get district operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDistrictParams struct {
 

--- a/client/districts/get_district_responses.go
+++ b/client/districts/get_district_responses.go
@@ -36,7 +36,7 @@ func (o *GetDistrictReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /districts/{id}] getDistrict", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetDistrictOK() *GetDistrictOK {
 	return &GetDistrictOK{}
 }
 
-/* GetDistrictOK describes a response with status code 200, with default header values.
+/*
+GetDistrictOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetDistrictOK struct {
 	Payload *models.DistrictResponse
 }
 
+// IsSuccess returns true when this get district o k response has a 2xx status code
+func (o *GetDistrictOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get district o k response has a 3xx status code
+func (o *GetDistrictOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district o k response has a 4xx status code
+func (o *GetDistrictOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get district o k response has a 5xx status code
+func (o *GetDistrictOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district o k response a status code equal to that given
+func (o *GetDistrictOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get district o k response
+func (o *GetDistrictOK) Code() int {
+	return 200
+}
+
 func (o *GetDistrictOK) Error() string {
 	return fmt.Sprintf("[GET /districts/{id}][%d] getDistrictOK  %+v", 200, o.Payload)
 }
+
+func (o *GetDistrictOK) String() string {
+	return fmt.Sprintf("[GET /districts/{id}][%d] getDistrictOK  %+v", 200, o.Payload)
+}
+
 func (o *GetDistrictOK) GetPayload() *models.DistrictResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetDistrictNotFound() *GetDistrictNotFound {
 	return &GetDistrictNotFound{}
 }
 
-/* GetDistrictNotFound describes a response with status code 404, with default header values.
+/*
+GetDistrictNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetDistrictNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get district not found response has a 2xx status code
+func (o *GetDistrictNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get district not found response has a 3xx status code
+func (o *GetDistrictNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district not found response has a 4xx status code
+func (o *GetDistrictNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get district not found response has a 5xx status code
+func (o *GetDistrictNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district not found response a status code equal to that given
+func (o *GetDistrictNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get district not found response
+func (o *GetDistrictNotFound) Code() int {
+	return 404
+}
+
 func (o *GetDistrictNotFound) Error() string {
 	return fmt.Sprintf("[GET /districts/{id}][%d] getDistrictNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetDistrictNotFound) String() string {
+	return fmt.Sprintf("[GET /districts/{id}][%d] getDistrictNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetDistrictNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/districts/get_districts_parameters.go
+++ b/client/districts/get_districts_parameters.go
@@ -52,10 +52,12 @@ func NewGetDistrictsParamsWithHTTPClient(client *http.Client) *GetDistrictsParam
 	}
 }
 
-/* GetDistrictsParams contains all the parameters to send to the API endpoint
-   for the get districts operation.
+/*
+GetDistrictsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get districts operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDistrictsParams struct {
 

--- a/client/districts/get_districts_responses.go
+++ b/client/districts/get_districts_responses.go
@@ -30,7 +30,7 @@ func (o *GetDistrictsReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /districts] getDistricts", response, response.Code())
 	}
 }
 
@@ -39,7 +39,8 @@ func NewGetDistrictsOK() *GetDistrictsOK {
 	return &GetDistrictsOK{}
 }
 
-/* GetDistrictsOK describes a response with status code 200, with default header values.
+/*
+GetDistrictsOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -47,9 +48,44 @@ type GetDistrictsOK struct {
 	Payload *models.DistrictsResponse
 }
 
+// IsSuccess returns true when this get districts o k response has a 2xx status code
+func (o *GetDistrictsOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get districts o k response has a 3xx status code
+func (o *GetDistrictsOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get districts o k response has a 4xx status code
+func (o *GetDistrictsOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get districts o k response has a 5xx status code
+func (o *GetDistrictsOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get districts o k response a status code equal to that given
+func (o *GetDistrictsOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get districts o k response
+func (o *GetDistrictsOK) Code() int {
+	return 200
+}
+
 func (o *GetDistrictsOK) Error() string {
 	return fmt.Sprintf("[GET /districts][%d] getDistrictsOK  %+v", 200, o.Payload)
 }
+
+func (o *GetDistrictsOK) String() string {
+	return fmt.Sprintf("[GET /districts][%d] getDistrictsOK  %+v", 200, o.Payload)
+}
+
 func (o *GetDistrictsOK) GetPayload() *models.DistrictsResponse {
 	return o.Payload
 }

--- a/client/events/events_client.go
+++ b/client/events/events_client.go
@@ -38,7 +38,7 @@ type ClientService interface {
 }
 
 /*
-  GetEvent Returns the specific event
+GetEvent Returns the specific event
 */
 func (a *Client) GetEvent(params *GetEventParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetEventOK, error) {
 	// TODO: Validate the params before sending
@@ -77,7 +77,7 @@ func (a *Client) GetEvent(params *GetEventParams, authInfo runtime.ClientAuthInf
 }
 
 /*
-  GetEvents Returns a list of events
+GetEvents Returns a list of events
 */
 func (a *Client) GetEvents(params *GetEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetEventsOK, error) {
 	// TODO: Validate the params before sending

--- a/client/events/get_event_parameters.go
+++ b/client/events/get_event_parameters.go
@@ -52,10 +52,12 @@ func NewGetEventParamsWithHTTPClient(client *http.Client) *GetEventParams {
 	}
 }
 
-/* GetEventParams contains all the parameters to send to the API endpoint
-   for the get event operation.
+/*
+GetEventParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get event operation.
+
+	Typically these are written to a http.Request.
 */
 type GetEventParams struct {
 

--- a/client/events/get_event_responses.go
+++ b/client/events/get_event_responses.go
@@ -36,7 +36,7 @@ func (o *GetEventReader) ReadResponse(response runtime.ClientResponse, consumer 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /events/{id}] getEvent", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetEventOK() *GetEventOK {
 	return &GetEventOK{}
 }
 
-/* GetEventOK describes a response with status code 200, with default header values.
+/*
+GetEventOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetEventOK struct {
 	Payload *models.EventResponse
 }
 
+// IsSuccess returns true when this get event o k response has a 2xx status code
+func (o *GetEventOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get event o k response has a 3xx status code
+func (o *GetEventOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get event o k response has a 4xx status code
+func (o *GetEventOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get event o k response has a 5xx status code
+func (o *GetEventOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get event o k response a status code equal to that given
+func (o *GetEventOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get event o k response
+func (o *GetEventOK) Code() int {
+	return 200
+}
+
 func (o *GetEventOK) Error() string {
 	return fmt.Sprintf("[GET /events/{id}][%d] getEventOK  %+v", 200, o.Payload)
 }
+
+func (o *GetEventOK) String() string {
+	return fmt.Sprintf("[GET /events/{id}][%d] getEventOK  %+v", 200, o.Payload)
+}
+
 func (o *GetEventOK) GetPayload() *models.EventResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetEventNotFound() *GetEventNotFound {
 	return &GetEventNotFound{}
 }
 
-/* GetEventNotFound describes a response with status code 404, with default header values.
+/*
+GetEventNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetEventNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get event not found response has a 2xx status code
+func (o *GetEventNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get event not found response has a 3xx status code
+func (o *GetEventNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get event not found response has a 4xx status code
+func (o *GetEventNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get event not found response has a 5xx status code
+func (o *GetEventNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get event not found response a status code equal to that given
+func (o *GetEventNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get event not found response
+func (o *GetEventNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEventNotFound) Error() string {
 	return fmt.Sprintf("[GET /events/{id}][%d] getEventNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetEventNotFound) String() string {
+	return fmt.Sprintf("[GET /events/{id}][%d] getEventNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetEventNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/events/get_events_parameters.go
+++ b/client/events/get_events_parameters.go
@@ -53,10 +53,12 @@ func NewGetEventsParamsWithHTTPClient(client *http.Client) *GetEventsParams {
 	}
 }
 
-/* GetEventsParams contains all the parameters to send to the API endpoint
-   for the get events operation.
+/*
+GetEventsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get events operation.
+
+	Typically these are written to a http.Request.
 */
 type GetEventsParams struct {
 

--- a/client/events/get_events_responses.go
+++ b/client/events/get_events_responses.go
@@ -36,7 +36,7 @@ func (o *GetEventsReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /events] getEvents", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetEventsOK() *GetEventsOK {
 	return &GetEventsOK{}
 }
 
-/* GetEventsOK describes a response with status code 200, with default header values.
+/*
+GetEventsOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetEventsOK struct {
 	Payload *models.EventsResponse
 }
 
+// IsSuccess returns true when this get events o k response has a 2xx status code
+func (o *GetEventsOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get events o k response has a 3xx status code
+func (o *GetEventsOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get events o k response has a 4xx status code
+func (o *GetEventsOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get events o k response has a 5xx status code
+func (o *GetEventsOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get events o k response a status code equal to that given
+func (o *GetEventsOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get events o k response
+func (o *GetEventsOK) Code() int {
+	return 200
+}
+
 func (o *GetEventsOK) Error() string {
 	return fmt.Sprintf("[GET /events][%d] getEventsOK  %+v", 200, o.Payload)
 }
+
+func (o *GetEventsOK) String() string {
+	return fmt.Sprintf("[GET /events][%d] getEventsOK  %+v", 200, o.Payload)
+}
+
 func (o *GetEventsOK) GetPayload() *models.EventsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetEventsNotFound() *GetEventsNotFound {
 	return &GetEventsNotFound{}
 }
 
-/* GetEventsNotFound describes a response with status code 404, with default header values.
+/*
+GetEventsNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetEventsNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get events not found response has a 2xx status code
+func (o *GetEventsNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get events not found response has a 3xx status code
+func (o *GetEventsNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get events not found response has a 4xx status code
+func (o *GetEventsNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get events not found response has a 5xx status code
+func (o *GetEventsNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get events not found response a status code equal to that given
+func (o *GetEventsNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get events not found response
+func (o *GetEventsNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEventsNotFound) Error() string {
 	return fmt.Sprintf("[GET /events][%d] getEventsNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetEventsNotFound) String() string {
+	return fmt.Sprintf("[GET /events][%d] getEventsNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetEventsNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/resources/get_courses_for_resource_parameters.go
+++ b/client/resources/get_courses_for_resource_parameters.go
@@ -53,10 +53,12 @@ func NewGetCoursesForResourceParamsWithHTTPClient(client *http.Client) *GetCours
 	}
 }
 
-/* GetCoursesForResourceParams contains all the parameters to send to the API endpoint
-   for the get courses for resource operation.
+/*
+GetCoursesForResourceParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get courses for resource operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCoursesForResourceParams struct {
 

--- a/client/resources/get_courses_for_resource_responses.go
+++ b/client/resources/get_courses_for_resource_responses.go
@@ -36,7 +36,7 @@ func (o *GetCoursesForResourceReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /resources/{id}/courses] getCoursesForResource", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetCoursesForResourceOK() *GetCoursesForResourceOK {
 	return &GetCoursesForResourceOK{}
 }
 
-/* GetCoursesForResourceOK describes a response with status code 200, with default header values.
+/*
+GetCoursesForResourceOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetCoursesForResourceOK struct {
 	Payload *models.CoursesResponse
 }
 
+// IsSuccess returns true when this get courses for resource o k response has a 2xx status code
+func (o *GetCoursesForResourceOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get courses for resource o k response has a 3xx status code
+func (o *GetCoursesForResourceOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get courses for resource o k response has a 4xx status code
+func (o *GetCoursesForResourceOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get courses for resource o k response has a 5xx status code
+func (o *GetCoursesForResourceOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get courses for resource o k response a status code equal to that given
+func (o *GetCoursesForResourceOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get courses for resource o k response
+func (o *GetCoursesForResourceOK) Code() int {
+	return 200
+}
+
 func (o *GetCoursesForResourceOK) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}/courses][%d] getCoursesForResourceOK  %+v", 200, o.Payload)
 }
+
+func (o *GetCoursesForResourceOK) String() string {
+	return fmt.Sprintf("[GET /resources/{id}/courses][%d] getCoursesForResourceOK  %+v", 200, o.Payload)
+}
+
 func (o *GetCoursesForResourceOK) GetPayload() *models.CoursesResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetCoursesForResourceNotFound() *GetCoursesForResourceNotFound {
 	return &GetCoursesForResourceNotFound{}
 }
 
-/* GetCoursesForResourceNotFound describes a response with status code 404, with default header values.
+/*
+GetCoursesForResourceNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetCoursesForResourceNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get courses for resource not found response has a 2xx status code
+func (o *GetCoursesForResourceNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get courses for resource not found response has a 3xx status code
+func (o *GetCoursesForResourceNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get courses for resource not found response has a 4xx status code
+func (o *GetCoursesForResourceNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get courses for resource not found response has a 5xx status code
+func (o *GetCoursesForResourceNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get courses for resource not found response a status code equal to that given
+func (o *GetCoursesForResourceNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get courses for resource not found response
+func (o *GetCoursesForResourceNotFound) Code() int {
+	return 404
+}
+
 func (o *GetCoursesForResourceNotFound) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}/courses][%d] getCoursesForResourceNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetCoursesForResourceNotFound) String() string {
+	return fmt.Sprintf("[GET /resources/{id}/courses][%d] getCoursesForResourceNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetCoursesForResourceNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/resources/get_resource_parameters.go
+++ b/client/resources/get_resource_parameters.go
@@ -52,10 +52,12 @@ func NewGetResourceParamsWithHTTPClient(client *http.Client) *GetResourceParams 
 	}
 }
 
-/* GetResourceParams contains all the parameters to send to the API endpoint
-   for the get resource operation.
+/*
+GetResourceParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get resource operation.
+
+	Typically these are written to a http.Request.
 */
 type GetResourceParams struct {
 

--- a/client/resources/get_resource_responses.go
+++ b/client/resources/get_resource_responses.go
@@ -36,7 +36,7 @@ func (o *GetResourceReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /resources/{id}] getResource", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetResourceOK() *GetResourceOK {
 	return &GetResourceOK{}
 }
 
-/* GetResourceOK describes a response with status code 200, with default header values.
+/*
+GetResourceOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetResourceOK struct {
 	Payload *models.ResourceResponse
 }
 
+// IsSuccess returns true when this get resource o k response has a 2xx status code
+func (o *GetResourceOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get resource o k response has a 3xx status code
+func (o *GetResourceOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resource o k response has a 4xx status code
+func (o *GetResourceOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get resource o k response has a 5xx status code
+func (o *GetResourceOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resource o k response a status code equal to that given
+func (o *GetResourceOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get resource o k response
+func (o *GetResourceOK) Code() int {
+	return 200
+}
+
 func (o *GetResourceOK) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}][%d] getResourceOK  %+v", 200, o.Payload)
 }
+
+func (o *GetResourceOK) String() string {
+	return fmt.Sprintf("[GET /resources/{id}][%d] getResourceOK  %+v", 200, o.Payload)
+}
+
 func (o *GetResourceOK) GetPayload() *models.ResourceResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetResourceNotFound() *GetResourceNotFound {
 	return &GetResourceNotFound{}
 }
 
-/* GetResourceNotFound describes a response with status code 404, with default header values.
+/*
+GetResourceNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetResourceNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get resource not found response has a 2xx status code
+func (o *GetResourceNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get resource not found response has a 3xx status code
+func (o *GetResourceNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resource not found response has a 4xx status code
+func (o *GetResourceNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get resource not found response has a 5xx status code
+func (o *GetResourceNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resource not found response a status code equal to that given
+func (o *GetResourceNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get resource not found response
+func (o *GetResourceNotFound) Code() int {
+	return 404
+}
+
 func (o *GetResourceNotFound) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}][%d] getResourceNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetResourceNotFound) String() string {
+	return fmt.Sprintf("[GET /resources/{id}][%d] getResourceNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetResourceNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/resources/get_resources_parameters.go
+++ b/client/resources/get_resources_parameters.go
@@ -53,10 +53,12 @@ func NewGetResourcesParamsWithHTTPClient(client *http.Client) *GetResourcesParam
 	}
 }
 
-/* GetResourcesParams contains all the parameters to send to the API endpoint
-   for the get resources operation.
+/*
+GetResourcesParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get resources operation.
+
+	Typically these are written to a http.Request.
 */
 type GetResourcesParams struct {
 

--- a/client/resources/get_resources_responses.go
+++ b/client/resources/get_resources_responses.go
@@ -30,7 +30,7 @@ func (o *GetResourcesReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /resources] getResources", response, response.Code())
 	}
 }
 
@@ -39,7 +39,8 @@ func NewGetResourcesOK() *GetResourcesOK {
 	return &GetResourcesOK{}
 }
 
-/* GetResourcesOK describes a response with status code 200, with default header values.
+/*
+GetResourcesOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -47,9 +48,44 @@ type GetResourcesOK struct {
 	Payload *models.ResourcesResponse
 }
 
+// IsSuccess returns true when this get resources o k response has a 2xx status code
+func (o *GetResourcesOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get resources o k response has a 3xx status code
+func (o *GetResourcesOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resources o k response has a 4xx status code
+func (o *GetResourcesOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get resources o k response has a 5xx status code
+func (o *GetResourcesOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resources o k response a status code equal to that given
+func (o *GetResourcesOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get resources o k response
+func (o *GetResourcesOK) Code() int {
+	return 200
+}
+
 func (o *GetResourcesOK) Error() string {
 	return fmt.Sprintf("[GET /resources][%d] getResourcesOK  %+v", 200, o.Payload)
 }
+
+func (o *GetResourcesOK) String() string {
+	return fmt.Sprintf("[GET /resources][%d] getResourcesOK  %+v", 200, o.Payload)
+}
+
 func (o *GetResourcesOK) GetPayload() *models.ResourcesResponse {
 	return o.Payload
 }

--- a/client/resources/get_sections_for_resource_parameters.go
+++ b/client/resources/get_sections_for_resource_parameters.go
@@ -53,10 +53,12 @@ func NewGetSectionsForResourceParamsWithHTTPClient(client *http.Client) *GetSect
 	}
 }
 
-/* GetSectionsForResourceParams contains all the parameters to send to the API endpoint
-   for the get sections for resource operation.
+/*
+GetSectionsForResourceParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get sections for resource operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSectionsForResourceParams struct {
 

--- a/client/resources/get_sections_for_resource_responses.go
+++ b/client/resources/get_sections_for_resource_responses.go
@@ -36,7 +36,7 @@ func (o *GetSectionsForResourceReader) ReadResponse(response runtime.ClientRespo
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /resources/{id}/sections] getSectionsForResource", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSectionsForResourceOK() *GetSectionsForResourceOK {
 	return &GetSectionsForResourceOK{}
 }
 
-/* GetSectionsForResourceOK describes a response with status code 200, with default header values.
+/*
+GetSectionsForResourceOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSectionsForResourceOK struct {
 	Payload *models.SectionsResponse
 }
 
+// IsSuccess returns true when this get sections for resource o k response has a 2xx status code
+func (o *GetSectionsForResourceOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get sections for resource o k response has a 3xx status code
+func (o *GetSectionsForResourceOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for resource o k response has a 4xx status code
+func (o *GetSectionsForResourceOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get sections for resource o k response has a 5xx status code
+func (o *GetSectionsForResourceOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for resource o k response a status code equal to that given
+func (o *GetSectionsForResourceOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get sections for resource o k response
+func (o *GetSectionsForResourceOK) Code() int {
+	return 200
+}
+
 func (o *GetSectionsForResourceOK) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}/sections][%d] getSectionsForResourceOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSectionsForResourceOK) String() string {
+	return fmt.Sprintf("[GET /resources/{id}/sections][%d] getSectionsForResourceOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSectionsForResourceOK) GetPayload() *models.SectionsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSectionsForResourceNotFound() *GetSectionsForResourceNotFound {
 	return &GetSectionsForResourceNotFound{}
 }
 
-/* GetSectionsForResourceNotFound describes a response with status code 404, with default header values.
+/*
+GetSectionsForResourceNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSectionsForResourceNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get sections for resource not found response has a 2xx status code
+func (o *GetSectionsForResourceNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get sections for resource not found response has a 3xx status code
+func (o *GetSectionsForResourceNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for resource not found response has a 4xx status code
+func (o *GetSectionsForResourceNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get sections for resource not found response has a 5xx status code
+func (o *GetSectionsForResourceNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for resource not found response a status code equal to that given
+func (o *GetSectionsForResourceNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get sections for resource not found response
+func (o *GetSectionsForResourceNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSectionsForResourceNotFound) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}/sections][%d] getSectionsForResourceNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSectionsForResourceNotFound) String() string {
+	return fmt.Sprintf("[GET /resources/{id}/sections][%d] getSectionsForResourceNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSectionsForResourceNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/resources/get_users_for_resource_parameters.go
+++ b/client/resources/get_users_for_resource_parameters.go
@@ -53,10 +53,12 @@ func NewGetUsersForResourceParamsWithHTTPClient(client *http.Client) *GetUsersFo
 	}
 }
 
-/* GetUsersForResourceParams contains all the parameters to send to the API endpoint
-   for the get users for resource operation.
+/*
+GetUsersForResourceParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get users for resource operation.
+
+	Typically these are written to a http.Request.
 */
 type GetUsersForResourceParams struct {
 

--- a/client/resources/get_users_for_resource_responses.go
+++ b/client/resources/get_users_for_resource_responses.go
@@ -36,7 +36,7 @@ func (o *GetUsersForResourceReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /resources/{id}/users] getUsersForResource", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetUsersForResourceOK() *GetUsersForResourceOK {
 	return &GetUsersForResourceOK{}
 }
 
-/* GetUsersForResourceOK describes a response with status code 200, with default header values.
+/*
+GetUsersForResourceOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetUsersForResourceOK struct {
 	Payload *models.UsersResponse
 }
 
+// IsSuccess returns true when this get users for resource o k response has a 2xx status code
+func (o *GetUsersForResourceOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get users for resource o k response has a 3xx status code
+func (o *GetUsersForResourceOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get users for resource o k response has a 4xx status code
+func (o *GetUsersForResourceOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get users for resource o k response has a 5xx status code
+func (o *GetUsersForResourceOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get users for resource o k response a status code equal to that given
+func (o *GetUsersForResourceOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get users for resource o k response
+func (o *GetUsersForResourceOK) Code() int {
+	return 200
+}
+
 func (o *GetUsersForResourceOK) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}/users][%d] getUsersForResourceOK  %+v", 200, o.Payload)
 }
+
+func (o *GetUsersForResourceOK) String() string {
+	return fmt.Sprintf("[GET /resources/{id}/users][%d] getUsersForResourceOK  %+v", 200, o.Payload)
+}
+
 func (o *GetUsersForResourceOK) GetPayload() *models.UsersResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetUsersForResourceNotFound() *GetUsersForResourceNotFound {
 	return &GetUsersForResourceNotFound{}
 }
 
-/* GetUsersForResourceNotFound describes a response with status code 404, with default header values.
+/*
+GetUsersForResourceNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetUsersForResourceNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get users for resource not found response has a 2xx status code
+func (o *GetUsersForResourceNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get users for resource not found response has a 3xx status code
+func (o *GetUsersForResourceNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get users for resource not found response has a 4xx status code
+func (o *GetUsersForResourceNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get users for resource not found response has a 5xx status code
+func (o *GetUsersForResourceNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get users for resource not found response a status code equal to that given
+func (o *GetUsersForResourceNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get users for resource not found response
+func (o *GetUsersForResourceNotFound) Code() int {
+	return 404
+}
+
 func (o *GetUsersForResourceNotFound) Error() string {
 	return fmt.Sprintf("[GET /resources/{id}/users][%d] getUsersForResourceNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetUsersForResourceNotFound) String() string {
+	return fmt.Sprintf("[GET /resources/{id}/users][%d] getUsersForResourceNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetUsersForResourceNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/resources/resources_client.go
+++ b/client/resources/resources_client.go
@@ -44,7 +44,7 @@ type ClientService interface {
 }
 
 /*
-  GetCoursesForResource Returns the courses for a resource
+GetCoursesForResource Returns the courses for a resource
 */
 func (a *Client) GetCoursesForResource(params *GetCoursesForResourceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetCoursesForResourceOK, error) {
 	// TODO: Validate the params before sending
@@ -83,7 +83,7 @@ func (a *Client) GetCoursesForResource(params *GetCoursesForResourceParams, auth
 }
 
 /*
-  GetResource Returns a specific resource
+GetResource Returns a specific resource
 */
 func (a *Client) GetResource(params *GetResourceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetResourceOK, error) {
 	// TODO: Validate the params before sending
@@ -122,7 +122,7 @@ func (a *Client) GetResource(params *GetResourceParams, authInfo runtime.ClientA
 }
 
 /*
-  GetResources Returns a list of resources
+GetResources Returns a list of resources
 */
 func (a *Client) GetResources(params *GetResourcesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetResourcesOK, error) {
 	// TODO: Validate the params before sending
@@ -161,7 +161,7 @@ func (a *Client) GetResources(params *GetResourcesParams, authInfo runtime.Clien
 }
 
 /*
-  GetSectionsForResource Returns the sections for a resource
+GetSectionsForResource Returns the sections for a resource
 */
 func (a *Client) GetSectionsForResource(params *GetSectionsForResourceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSectionsForResourceOK, error) {
 	// TODO: Validate the params before sending
@@ -200,7 +200,7 @@ func (a *Client) GetSectionsForResource(params *GetSectionsForResourceParams, au
 }
 
 /*
-  GetUsersForResource Returns the student and/or teacher users for a resource
+GetUsersForResource Returns the student and/or teacher users for a resource
 */
 func (a *Client) GetUsersForResource(params *GetUsersForResourceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersForResourceOK, error) {
 	// TODO: Validate the params before sending

--- a/client/schools/get_courses_for_school_parameters.go
+++ b/client/schools/get_courses_for_school_parameters.go
@@ -53,10 +53,12 @@ func NewGetCoursesForSchoolParamsWithHTTPClient(client *http.Client) *GetCourses
 	}
 }
 
-/* GetCoursesForSchoolParams contains all the parameters to send to the API endpoint
-   for the get courses for school operation.
+/*
+GetCoursesForSchoolParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get courses for school operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCoursesForSchoolParams struct {
 

--- a/client/schools/get_courses_for_school_responses.go
+++ b/client/schools/get_courses_for_school_responses.go
@@ -36,7 +36,7 @@ func (o *GetCoursesForSchoolReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schools/{id}/courses] getCoursesForSchool", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetCoursesForSchoolOK() *GetCoursesForSchoolOK {
 	return &GetCoursesForSchoolOK{}
 }
 
-/* GetCoursesForSchoolOK describes a response with status code 200, with default header values.
+/*
+GetCoursesForSchoolOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetCoursesForSchoolOK struct {
 	Payload *models.CoursesResponse
 }
 
+// IsSuccess returns true when this get courses for school o k response has a 2xx status code
+func (o *GetCoursesForSchoolOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get courses for school o k response has a 3xx status code
+func (o *GetCoursesForSchoolOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get courses for school o k response has a 4xx status code
+func (o *GetCoursesForSchoolOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get courses for school o k response has a 5xx status code
+func (o *GetCoursesForSchoolOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get courses for school o k response a status code equal to that given
+func (o *GetCoursesForSchoolOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get courses for school o k response
+func (o *GetCoursesForSchoolOK) Code() int {
+	return 200
+}
+
 func (o *GetCoursesForSchoolOK) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/courses][%d] getCoursesForSchoolOK  %+v", 200, o.Payload)
 }
+
+func (o *GetCoursesForSchoolOK) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/courses][%d] getCoursesForSchoolOK  %+v", 200, o.Payload)
+}
+
 func (o *GetCoursesForSchoolOK) GetPayload() *models.CoursesResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetCoursesForSchoolNotFound() *GetCoursesForSchoolNotFound {
 	return &GetCoursesForSchoolNotFound{}
 }
 
-/* GetCoursesForSchoolNotFound describes a response with status code 404, with default header values.
+/*
+GetCoursesForSchoolNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetCoursesForSchoolNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get courses for school not found response has a 2xx status code
+func (o *GetCoursesForSchoolNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get courses for school not found response has a 3xx status code
+func (o *GetCoursesForSchoolNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get courses for school not found response has a 4xx status code
+func (o *GetCoursesForSchoolNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get courses for school not found response has a 5xx status code
+func (o *GetCoursesForSchoolNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get courses for school not found response a status code equal to that given
+func (o *GetCoursesForSchoolNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get courses for school not found response
+func (o *GetCoursesForSchoolNotFound) Code() int {
+	return 404
+}
+
 func (o *GetCoursesForSchoolNotFound) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/courses][%d] getCoursesForSchoolNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetCoursesForSchoolNotFound) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/courses][%d] getCoursesForSchoolNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetCoursesForSchoolNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/schools/get_district_for_school_parameters.go
+++ b/client/schools/get_district_for_school_parameters.go
@@ -52,10 +52,12 @@ func NewGetDistrictForSchoolParamsWithHTTPClient(client *http.Client) *GetDistri
 	}
 }
 
-/* GetDistrictForSchoolParams contains all the parameters to send to the API endpoint
-   for the get district for school operation.
+/*
+GetDistrictForSchoolParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get district for school operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDistrictForSchoolParams struct {
 

--- a/client/schools/get_district_for_school_responses.go
+++ b/client/schools/get_district_for_school_responses.go
@@ -36,7 +36,7 @@ func (o *GetDistrictForSchoolReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schools/{id}/district] getDistrictForSchool", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetDistrictForSchoolOK() *GetDistrictForSchoolOK {
 	return &GetDistrictForSchoolOK{}
 }
 
-/* GetDistrictForSchoolOK describes a response with status code 200, with default header values.
+/*
+GetDistrictForSchoolOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetDistrictForSchoolOK struct {
 	Payload *models.DistrictResponse
 }
 
+// IsSuccess returns true when this get district for school o k response has a 2xx status code
+func (o *GetDistrictForSchoolOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get district for school o k response has a 3xx status code
+func (o *GetDistrictForSchoolOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for school o k response has a 4xx status code
+func (o *GetDistrictForSchoolOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get district for school o k response has a 5xx status code
+func (o *GetDistrictForSchoolOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for school o k response a status code equal to that given
+func (o *GetDistrictForSchoolOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get district for school o k response
+func (o *GetDistrictForSchoolOK) Code() int {
+	return 200
+}
+
 func (o *GetDistrictForSchoolOK) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/district][%d] getDistrictForSchoolOK  %+v", 200, o.Payload)
 }
+
+func (o *GetDistrictForSchoolOK) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/district][%d] getDistrictForSchoolOK  %+v", 200, o.Payload)
+}
+
 func (o *GetDistrictForSchoolOK) GetPayload() *models.DistrictResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetDistrictForSchoolNotFound() *GetDistrictForSchoolNotFound {
 	return &GetDistrictForSchoolNotFound{}
 }
 
-/* GetDistrictForSchoolNotFound describes a response with status code 404, with default header values.
+/*
+GetDistrictForSchoolNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetDistrictForSchoolNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get district for school not found response has a 2xx status code
+func (o *GetDistrictForSchoolNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get district for school not found response has a 3xx status code
+func (o *GetDistrictForSchoolNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for school not found response has a 4xx status code
+func (o *GetDistrictForSchoolNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get district for school not found response has a 5xx status code
+func (o *GetDistrictForSchoolNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for school not found response a status code equal to that given
+func (o *GetDistrictForSchoolNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get district for school not found response
+func (o *GetDistrictForSchoolNotFound) Code() int {
+	return 404
+}
+
 func (o *GetDistrictForSchoolNotFound) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/district][%d] getDistrictForSchoolNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetDistrictForSchoolNotFound) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/district][%d] getDistrictForSchoolNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetDistrictForSchoolNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/schools/get_school_parameters.go
+++ b/client/schools/get_school_parameters.go
@@ -52,10 +52,12 @@ func NewGetSchoolParamsWithHTTPClient(client *http.Client) *GetSchoolParams {
 	}
 }
 
-/* GetSchoolParams contains all the parameters to send to the API endpoint
-   for the get school operation.
+/*
+GetSchoolParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get school operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSchoolParams struct {
 

--- a/client/schools/get_school_responses.go
+++ b/client/schools/get_school_responses.go
@@ -36,7 +36,7 @@ func (o *GetSchoolReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schools/{id}] getSchool", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSchoolOK() *GetSchoolOK {
 	return &GetSchoolOK{}
 }
 
-/* GetSchoolOK describes a response with status code 200, with default header values.
+/*
+GetSchoolOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSchoolOK struct {
 	Payload *models.SchoolResponse
 }
 
+// IsSuccess returns true when this get school o k response has a 2xx status code
+func (o *GetSchoolOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get school o k response has a 3xx status code
+func (o *GetSchoolOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get school o k response has a 4xx status code
+func (o *GetSchoolOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get school o k response has a 5xx status code
+func (o *GetSchoolOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get school o k response a status code equal to that given
+func (o *GetSchoolOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get school o k response
+func (o *GetSchoolOK) Code() int {
+	return 200
+}
+
 func (o *GetSchoolOK) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}][%d] getSchoolOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSchoolOK) String() string {
+	return fmt.Sprintf("[GET /schools/{id}][%d] getSchoolOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSchoolOK) GetPayload() *models.SchoolResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSchoolNotFound() *GetSchoolNotFound {
 	return &GetSchoolNotFound{}
 }
 
-/* GetSchoolNotFound describes a response with status code 404, with default header values.
+/*
+GetSchoolNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSchoolNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get school not found response has a 2xx status code
+func (o *GetSchoolNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get school not found response has a 3xx status code
+func (o *GetSchoolNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get school not found response has a 4xx status code
+func (o *GetSchoolNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get school not found response has a 5xx status code
+func (o *GetSchoolNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get school not found response a status code equal to that given
+func (o *GetSchoolNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get school not found response
+func (o *GetSchoolNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSchoolNotFound) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}][%d] getSchoolNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSchoolNotFound) String() string {
+	return fmt.Sprintf("[GET /schools/{id}][%d] getSchoolNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSchoolNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/schools/get_schools_parameters.go
+++ b/client/schools/get_schools_parameters.go
@@ -53,10 +53,12 @@ func NewGetSchoolsParamsWithHTTPClient(client *http.Client) *GetSchoolsParams {
 	}
 }
 
-/* GetSchoolsParams contains all the parameters to send to the API endpoint
-   for the get schools operation.
+/*
+GetSchoolsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get schools operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSchoolsParams struct {
 

--- a/client/schools/get_schools_responses.go
+++ b/client/schools/get_schools_responses.go
@@ -30,7 +30,7 @@ func (o *GetSchoolsReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schools] getSchools", response, response.Code())
 	}
 }
 
@@ -39,7 +39,8 @@ func NewGetSchoolsOK() *GetSchoolsOK {
 	return &GetSchoolsOK{}
 }
 
-/* GetSchoolsOK describes a response with status code 200, with default header values.
+/*
+GetSchoolsOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -47,9 +48,44 @@ type GetSchoolsOK struct {
 	Payload *models.SchoolsResponse
 }
 
+// IsSuccess returns true when this get schools o k response has a 2xx status code
+func (o *GetSchoolsOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get schools o k response has a 3xx status code
+func (o *GetSchoolsOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get schools o k response has a 4xx status code
+func (o *GetSchoolsOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get schools o k response has a 5xx status code
+func (o *GetSchoolsOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get schools o k response a status code equal to that given
+func (o *GetSchoolsOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get schools o k response
+func (o *GetSchoolsOK) Code() int {
+	return 200
+}
+
 func (o *GetSchoolsOK) Error() string {
 	return fmt.Sprintf("[GET /schools][%d] getSchoolsOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSchoolsOK) String() string {
+	return fmt.Sprintf("[GET /schools][%d] getSchoolsOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSchoolsOK) GetPayload() *models.SchoolsResponse {
 	return o.Payload
 }

--- a/client/schools/get_sections_for_school_parameters.go
+++ b/client/schools/get_sections_for_school_parameters.go
@@ -53,10 +53,12 @@ func NewGetSectionsForSchoolParamsWithHTTPClient(client *http.Client) *GetSectio
 	}
 }
 
-/* GetSectionsForSchoolParams contains all the parameters to send to the API endpoint
-   for the get sections for school operation.
+/*
+GetSectionsForSchoolParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get sections for school operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSectionsForSchoolParams struct {
 

--- a/client/schools/get_sections_for_school_responses.go
+++ b/client/schools/get_sections_for_school_responses.go
@@ -36,7 +36,7 @@ func (o *GetSectionsForSchoolReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schools/{id}/sections] getSectionsForSchool", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSectionsForSchoolOK() *GetSectionsForSchoolOK {
 	return &GetSectionsForSchoolOK{}
 }
 
-/* GetSectionsForSchoolOK describes a response with status code 200, with default header values.
+/*
+GetSectionsForSchoolOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSectionsForSchoolOK struct {
 	Payload *models.SectionsResponse
 }
 
+// IsSuccess returns true when this get sections for school o k response has a 2xx status code
+func (o *GetSectionsForSchoolOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get sections for school o k response has a 3xx status code
+func (o *GetSectionsForSchoolOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for school o k response has a 4xx status code
+func (o *GetSectionsForSchoolOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get sections for school o k response has a 5xx status code
+func (o *GetSectionsForSchoolOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for school o k response a status code equal to that given
+func (o *GetSectionsForSchoolOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get sections for school o k response
+func (o *GetSectionsForSchoolOK) Code() int {
+	return 200
+}
+
 func (o *GetSectionsForSchoolOK) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/sections][%d] getSectionsForSchoolOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSectionsForSchoolOK) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/sections][%d] getSectionsForSchoolOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSectionsForSchoolOK) GetPayload() *models.SectionsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSectionsForSchoolNotFound() *GetSectionsForSchoolNotFound {
 	return &GetSectionsForSchoolNotFound{}
 }
 
-/* GetSectionsForSchoolNotFound describes a response with status code 404, with default header values.
+/*
+GetSectionsForSchoolNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSectionsForSchoolNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get sections for school not found response has a 2xx status code
+func (o *GetSectionsForSchoolNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get sections for school not found response has a 3xx status code
+func (o *GetSectionsForSchoolNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for school not found response has a 4xx status code
+func (o *GetSectionsForSchoolNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get sections for school not found response has a 5xx status code
+func (o *GetSectionsForSchoolNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for school not found response a status code equal to that given
+func (o *GetSectionsForSchoolNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get sections for school not found response
+func (o *GetSectionsForSchoolNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSectionsForSchoolNotFound) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/sections][%d] getSectionsForSchoolNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSectionsForSchoolNotFound) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/sections][%d] getSectionsForSchoolNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSectionsForSchoolNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/schools/get_terms_for_school_parameters.go
+++ b/client/schools/get_terms_for_school_parameters.go
@@ -53,10 +53,12 @@ func NewGetTermsForSchoolParamsWithHTTPClient(client *http.Client) *GetTermsForS
 	}
 }
 
-/* GetTermsForSchoolParams contains all the parameters to send to the API endpoint
-   for the get terms for school operation.
+/*
+GetTermsForSchoolParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get terms for school operation.
+
+	Typically these are written to a http.Request.
 */
 type GetTermsForSchoolParams struct {
 

--- a/client/schools/get_terms_for_school_responses.go
+++ b/client/schools/get_terms_for_school_responses.go
@@ -36,7 +36,7 @@ func (o *GetTermsForSchoolReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schools/{id}/terms] getTermsForSchool", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetTermsForSchoolOK() *GetTermsForSchoolOK {
 	return &GetTermsForSchoolOK{}
 }
 
-/* GetTermsForSchoolOK describes a response with status code 200, with default header values.
+/*
+GetTermsForSchoolOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetTermsForSchoolOK struct {
 	Payload *models.TermsResponse
 }
 
+// IsSuccess returns true when this get terms for school o k response has a 2xx status code
+func (o *GetTermsForSchoolOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get terms for school o k response has a 3xx status code
+func (o *GetTermsForSchoolOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get terms for school o k response has a 4xx status code
+func (o *GetTermsForSchoolOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get terms for school o k response has a 5xx status code
+func (o *GetTermsForSchoolOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get terms for school o k response a status code equal to that given
+func (o *GetTermsForSchoolOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get terms for school o k response
+func (o *GetTermsForSchoolOK) Code() int {
+	return 200
+}
+
 func (o *GetTermsForSchoolOK) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/terms][%d] getTermsForSchoolOK  %+v", 200, o.Payload)
 }
+
+func (o *GetTermsForSchoolOK) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/terms][%d] getTermsForSchoolOK  %+v", 200, o.Payload)
+}
+
 func (o *GetTermsForSchoolOK) GetPayload() *models.TermsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetTermsForSchoolNotFound() *GetTermsForSchoolNotFound {
 	return &GetTermsForSchoolNotFound{}
 }
 
-/* GetTermsForSchoolNotFound describes a response with status code 404, with default header values.
+/*
+GetTermsForSchoolNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetTermsForSchoolNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get terms for school not found response has a 2xx status code
+func (o *GetTermsForSchoolNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get terms for school not found response has a 3xx status code
+func (o *GetTermsForSchoolNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get terms for school not found response has a 4xx status code
+func (o *GetTermsForSchoolNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get terms for school not found response has a 5xx status code
+func (o *GetTermsForSchoolNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get terms for school not found response a status code equal to that given
+func (o *GetTermsForSchoolNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get terms for school not found response
+func (o *GetTermsForSchoolNotFound) Code() int {
+	return 404
+}
+
 func (o *GetTermsForSchoolNotFound) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/terms][%d] getTermsForSchoolNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetTermsForSchoolNotFound) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/terms][%d] getTermsForSchoolNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetTermsForSchoolNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/schools/get_users_for_school_parameters.go
+++ b/client/schools/get_users_for_school_parameters.go
@@ -53,10 +53,12 @@ func NewGetUsersForSchoolParamsWithHTTPClient(client *http.Client) *GetUsersForS
 	}
 }
 
-/* GetUsersForSchoolParams contains all the parameters to send to the API endpoint
-   for the get users for school operation.
+/*
+GetUsersForSchoolParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get users for school operation.
+
+	Typically these are written to a http.Request.
 */
 type GetUsersForSchoolParams struct {
 

--- a/client/schools/get_users_for_school_responses.go
+++ b/client/schools/get_users_for_school_responses.go
@@ -36,7 +36,7 @@ func (o *GetUsersForSchoolReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schools/{id}/users] getUsersForSchool", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetUsersForSchoolOK() *GetUsersForSchoolOK {
 	return &GetUsersForSchoolOK{}
 }
 
-/* GetUsersForSchoolOK describes a response with status code 200, with default header values.
+/*
+GetUsersForSchoolOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetUsersForSchoolOK struct {
 	Payload *models.UsersResponse
 }
 
+// IsSuccess returns true when this get users for school o k response has a 2xx status code
+func (o *GetUsersForSchoolOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get users for school o k response has a 3xx status code
+func (o *GetUsersForSchoolOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get users for school o k response has a 4xx status code
+func (o *GetUsersForSchoolOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get users for school o k response has a 5xx status code
+func (o *GetUsersForSchoolOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get users for school o k response a status code equal to that given
+func (o *GetUsersForSchoolOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get users for school o k response
+func (o *GetUsersForSchoolOK) Code() int {
+	return 200
+}
+
 func (o *GetUsersForSchoolOK) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/users][%d] getUsersForSchoolOK  %+v", 200, o.Payload)
 }
+
+func (o *GetUsersForSchoolOK) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/users][%d] getUsersForSchoolOK  %+v", 200, o.Payload)
+}
+
 func (o *GetUsersForSchoolOK) GetPayload() *models.UsersResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetUsersForSchoolNotFound() *GetUsersForSchoolNotFound {
 	return &GetUsersForSchoolNotFound{}
 }
 
-/* GetUsersForSchoolNotFound describes a response with status code 404, with default header values.
+/*
+GetUsersForSchoolNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetUsersForSchoolNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get users for school not found response has a 2xx status code
+func (o *GetUsersForSchoolNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get users for school not found response has a 3xx status code
+func (o *GetUsersForSchoolNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get users for school not found response has a 4xx status code
+func (o *GetUsersForSchoolNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get users for school not found response has a 5xx status code
+func (o *GetUsersForSchoolNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get users for school not found response a status code equal to that given
+func (o *GetUsersForSchoolNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get users for school not found response
+func (o *GetUsersForSchoolNotFound) Code() int {
+	return 404
+}
+
 func (o *GetUsersForSchoolNotFound) Error() string {
 	return fmt.Sprintf("[GET /schools/{id}/users][%d] getUsersForSchoolNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetUsersForSchoolNotFound) String() string {
+	return fmt.Sprintf("[GET /schools/{id}/users][%d] getUsersForSchoolNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetUsersForSchoolNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/schools/schools_client.go
+++ b/client/schools/schools_client.go
@@ -48,7 +48,7 @@ type ClientService interface {
 }
 
 /*
-  GetCoursesForSchool Returns the courses for a school
+GetCoursesForSchool Returns the courses for a school
 */
 func (a *Client) GetCoursesForSchool(params *GetCoursesForSchoolParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetCoursesForSchoolOK, error) {
 	// TODO: Validate the params before sending
@@ -87,7 +87,7 @@ func (a *Client) GetCoursesForSchool(params *GetCoursesForSchoolParams, authInfo
 }
 
 /*
-  GetDistrictForSchool Returns the district for a school
+GetDistrictForSchool Returns the district for a school
 */
 func (a *Client) GetDistrictForSchool(params *GetDistrictForSchoolParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetDistrictForSchoolOK, error) {
 	// TODO: Validate the params before sending
@@ -126,7 +126,7 @@ func (a *Client) GetDistrictForSchool(params *GetDistrictForSchoolParams, authIn
 }
 
 /*
-  GetSchool Returns a specific school
+GetSchool Returns a specific school
 */
 func (a *Client) GetSchool(params *GetSchoolParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSchoolOK, error) {
 	// TODO: Validate the params before sending
@@ -165,7 +165,7 @@ func (a *Client) GetSchool(params *GetSchoolParams, authInfo runtime.ClientAuthI
 }
 
 /*
-  GetSchools Returns a list of schools
+GetSchools Returns a list of schools
 */
 func (a *Client) GetSchools(params *GetSchoolsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSchoolsOK, error) {
 	// TODO: Validate the params before sending
@@ -204,7 +204,7 @@ func (a *Client) GetSchools(params *GetSchoolsParams, authInfo runtime.ClientAut
 }
 
 /*
-  GetSectionsForSchool Returns the sections for a school
+GetSectionsForSchool Returns the sections for a school
 */
 func (a *Client) GetSectionsForSchool(params *GetSectionsForSchoolParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSectionsForSchoolOK, error) {
 	// TODO: Validate the params before sending
@@ -243,7 +243,7 @@ func (a *Client) GetSectionsForSchool(params *GetSectionsForSchoolParams, authIn
 }
 
 /*
-  GetTermsForSchool Returns the terms for a school
+GetTermsForSchool Returns the terms for a school
 */
 func (a *Client) GetTermsForSchool(params *GetTermsForSchoolParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetTermsForSchoolOK, error) {
 	// TODO: Validate the params before sending
@@ -282,7 +282,7 @@ func (a *Client) GetTermsForSchool(params *GetTermsForSchoolParams, authInfo run
 }
 
 /*
-  GetUsersForSchool Returns the staff, student, and/or teacher users for a school
+GetUsersForSchool Returns the staff, student, and/or teacher users for a school
 */
 func (a *Client) GetUsersForSchool(params *GetUsersForSchoolParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersForSchoolOK, error) {
 	// TODO: Validate the params before sending

--- a/client/sections/get_course_for_section_parameters.go
+++ b/client/sections/get_course_for_section_parameters.go
@@ -52,10 +52,12 @@ func NewGetCourseForSectionParamsWithHTTPClient(client *http.Client) *GetCourseF
 	}
 }
 
-/* GetCourseForSectionParams contains all the parameters to send to the API endpoint
-   for the get course for section operation.
+/*
+GetCourseForSectionParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get course for section operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCourseForSectionParams struct {
 

--- a/client/sections/get_course_for_section_responses.go
+++ b/client/sections/get_course_for_section_responses.go
@@ -36,7 +36,7 @@ func (o *GetCourseForSectionReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections/{id}/course] getCourseForSection", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetCourseForSectionOK() *GetCourseForSectionOK {
 	return &GetCourseForSectionOK{}
 }
 
-/* GetCourseForSectionOK describes a response with status code 200, with default header values.
+/*
+GetCourseForSectionOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetCourseForSectionOK struct {
 	Payload *models.CourseResponse
 }
 
+// IsSuccess returns true when this get course for section o k response has a 2xx status code
+func (o *GetCourseForSectionOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get course for section o k response has a 3xx status code
+func (o *GetCourseForSectionOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get course for section o k response has a 4xx status code
+func (o *GetCourseForSectionOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get course for section o k response has a 5xx status code
+func (o *GetCourseForSectionOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get course for section o k response a status code equal to that given
+func (o *GetCourseForSectionOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get course for section o k response
+func (o *GetCourseForSectionOK) Code() int {
+	return 200
+}
+
 func (o *GetCourseForSectionOK) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/course][%d] getCourseForSectionOK  %+v", 200, o.Payload)
 }
+
+func (o *GetCourseForSectionOK) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/course][%d] getCourseForSectionOK  %+v", 200, o.Payload)
+}
+
 func (o *GetCourseForSectionOK) GetPayload() *models.CourseResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetCourseForSectionNotFound() *GetCourseForSectionNotFound {
 	return &GetCourseForSectionNotFound{}
 }
 
-/* GetCourseForSectionNotFound describes a response with status code 404, with default header values.
+/*
+GetCourseForSectionNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetCourseForSectionNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get course for section not found response has a 2xx status code
+func (o *GetCourseForSectionNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get course for section not found response has a 3xx status code
+func (o *GetCourseForSectionNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get course for section not found response has a 4xx status code
+func (o *GetCourseForSectionNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get course for section not found response has a 5xx status code
+func (o *GetCourseForSectionNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get course for section not found response a status code equal to that given
+func (o *GetCourseForSectionNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get course for section not found response
+func (o *GetCourseForSectionNotFound) Code() int {
+	return 404
+}
+
 func (o *GetCourseForSectionNotFound) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/course][%d] getCourseForSectionNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetCourseForSectionNotFound) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/course][%d] getCourseForSectionNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetCourseForSectionNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/sections/get_district_for_section_parameters.go
+++ b/client/sections/get_district_for_section_parameters.go
@@ -52,10 +52,12 @@ func NewGetDistrictForSectionParamsWithHTTPClient(client *http.Client) *GetDistr
 	}
 }
 
-/* GetDistrictForSectionParams contains all the parameters to send to the API endpoint
-   for the get district for section operation.
+/*
+GetDistrictForSectionParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get district for section operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDistrictForSectionParams struct {
 

--- a/client/sections/get_district_for_section_responses.go
+++ b/client/sections/get_district_for_section_responses.go
@@ -36,7 +36,7 @@ func (o *GetDistrictForSectionReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections/{id}/district] getDistrictForSection", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetDistrictForSectionOK() *GetDistrictForSectionOK {
 	return &GetDistrictForSectionOK{}
 }
 
-/* GetDistrictForSectionOK describes a response with status code 200, with default header values.
+/*
+GetDistrictForSectionOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetDistrictForSectionOK struct {
 	Payload *models.DistrictResponse
 }
 
+// IsSuccess returns true when this get district for section o k response has a 2xx status code
+func (o *GetDistrictForSectionOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get district for section o k response has a 3xx status code
+func (o *GetDistrictForSectionOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for section o k response has a 4xx status code
+func (o *GetDistrictForSectionOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get district for section o k response has a 5xx status code
+func (o *GetDistrictForSectionOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for section o k response a status code equal to that given
+func (o *GetDistrictForSectionOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get district for section o k response
+func (o *GetDistrictForSectionOK) Code() int {
+	return 200
+}
+
 func (o *GetDistrictForSectionOK) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/district][%d] getDistrictForSectionOK  %+v", 200, o.Payload)
 }
+
+func (o *GetDistrictForSectionOK) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/district][%d] getDistrictForSectionOK  %+v", 200, o.Payload)
+}
+
 func (o *GetDistrictForSectionOK) GetPayload() *models.DistrictResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetDistrictForSectionNotFound() *GetDistrictForSectionNotFound {
 	return &GetDistrictForSectionNotFound{}
 }
 
-/* GetDistrictForSectionNotFound describes a response with status code 404, with default header values.
+/*
+GetDistrictForSectionNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetDistrictForSectionNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get district for section not found response has a 2xx status code
+func (o *GetDistrictForSectionNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get district for section not found response has a 3xx status code
+func (o *GetDistrictForSectionNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for section not found response has a 4xx status code
+func (o *GetDistrictForSectionNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get district for section not found response has a 5xx status code
+func (o *GetDistrictForSectionNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for section not found response a status code equal to that given
+func (o *GetDistrictForSectionNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get district for section not found response
+func (o *GetDistrictForSectionNotFound) Code() int {
+	return 404
+}
+
 func (o *GetDistrictForSectionNotFound) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/district][%d] getDistrictForSectionNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetDistrictForSectionNotFound) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/district][%d] getDistrictForSectionNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetDistrictForSectionNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/sections/get_resources_for_section_parameters.go
+++ b/client/sections/get_resources_for_section_parameters.go
@@ -53,10 +53,12 @@ func NewGetResourcesForSectionParamsWithHTTPClient(client *http.Client) *GetReso
 	}
 }
 
-/* GetResourcesForSectionParams contains all the parameters to send to the API endpoint
-   for the get resources for section operation.
+/*
+GetResourcesForSectionParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get resources for section operation.
+
+	Typically these are written to a http.Request.
 */
 type GetResourcesForSectionParams struct {
 

--- a/client/sections/get_resources_for_section_responses.go
+++ b/client/sections/get_resources_for_section_responses.go
@@ -36,7 +36,7 @@ func (o *GetResourcesForSectionReader) ReadResponse(response runtime.ClientRespo
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections/{id}/resources] getResourcesForSection", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetResourcesForSectionOK() *GetResourcesForSectionOK {
 	return &GetResourcesForSectionOK{}
 }
 
-/* GetResourcesForSectionOK describes a response with status code 200, with default header values.
+/*
+GetResourcesForSectionOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetResourcesForSectionOK struct {
 	Payload *models.ResourcesResponse
 }
 
+// IsSuccess returns true when this get resources for section o k response has a 2xx status code
+func (o *GetResourcesForSectionOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get resources for section o k response has a 3xx status code
+func (o *GetResourcesForSectionOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resources for section o k response has a 4xx status code
+func (o *GetResourcesForSectionOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get resources for section o k response has a 5xx status code
+func (o *GetResourcesForSectionOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resources for section o k response a status code equal to that given
+func (o *GetResourcesForSectionOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get resources for section o k response
+func (o *GetResourcesForSectionOK) Code() int {
+	return 200
+}
+
 func (o *GetResourcesForSectionOK) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/resources][%d] getResourcesForSectionOK  %+v", 200, o.Payload)
 }
+
+func (o *GetResourcesForSectionOK) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/resources][%d] getResourcesForSectionOK  %+v", 200, o.Payload)
+}
+
 func (o *GetResourcesForSectionOK) GetPayload() *models.ResourcesResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetResourcesForSectionNotFound() *GetResourcesForSectionNotFound {
 	return &GetResourcesForSectionNotFound{}
 }
 
-/* GetResourcesForSectionNotFound describes a response with status code 404, with default header values.
+/*
+GetResourcesForSectionNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetResourcesForSectionNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get resources for section not found response has a 2xx status code
+func (o *GetResourcesForSectionNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get resources for section not found response has a 3xx status code
+func (o *GetResourcesForSectionNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resources for section not found response has a 4xx status code
+func (o *GetResourcesForSectionNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get resources for section not found response has a 5xx status code
+func (o *GetResourcesForSectionNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resources for section not found response a status code equal to that given
+func (o *GetResourcesForSectionNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get resources for section not found response
+func (o *GetResourcesForSectionNotFound) Code() int {
+	return 404
+}
+
 func (o *GetResourcesForSectionNotFound) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/resources][%d] getResourcesForSectionNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetResourcesForSectionNotFound) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/resources][%d] getResourcesForSectionNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetResourcesForSectionNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/sections/get_school_for_section_parameters.go
+++ b/client/sections/get_school_for_section_parameters.go
@@ -52,10 +52,12 @@ func NewGetSchoolForSectionParamsWithHTTPClient(client *http.Client) *GetSchoolF
 	}
 }
 
-/* GetSchoolForSectionParams contains all the parameters to send to the API endpoint
-   for the get school for section operation.
+/*
+GetSchoolForSectionParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get school for section operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSchoolForSectionParams struct {
 

--- a/client/sections/get_school_for_section_responses.go
+++ b/client/sections/get_school_for_section_responses.go
@@ -36,7 +36,7 @@ func (o *GetSchoolForSectionReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections/{id}/school] getSchoolForSection", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSchoolForSectionOK() *GetSchoolForSectionOK {
 	return &GetSchoolForSectionOK{}
 }
 
-/* GetSchoolForSectionOK describes a response with status code 200, with default header values.
+/*
+GetSchoolForSectionOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSchoolForSectionOK struct {
 	Payload *models.SchoolResponse
 }
 
+// IsSuccess returns true when this get school for section o k response has a 2xx status code
+func (o *GetSchoolForSectionOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get school for section o k response has a 3xx status code
+func (o *GetSchoolForSectionOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get school for section o k response has a 4xx status code
+func (o *GetSchoolForSectionOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get school for section o k response has a 5xx status code
+func (o *GetSchoolForSectionOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get school for section o k response a status code equal to that given
+func (o *GetSchoolForSectionOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get school for section o k response
+func (o *GetSchoolForSectionOK) Code() int {
+	return 200
+}
+
 func (o *GetSchoolForSectionOK) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/school][%d] getSchoolForSectionOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSchoolForSectionOK) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/school][%d] getSchoolForSectionOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSchoolForSectionOK) GetPayload() *models.SchoolResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSchoolForSectionNotFound() *GetSchoolForSectionNotFound {
 	return &GetSchoolForSectionNotFound{}
 }
 
-/* GetSchoolForSectionNotFound describes a response with status code 404, with default header values.
+/*
+GetSchoolForSectionNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSchoolForSectionNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get school for section not found response has a 2xx status code
+func (o *GetSchoolForSectionNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get school for section not found response has a 3xx status code
+func (o *GetSchoolForSectionNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get school for section not found response has a 4xx status code
+func (o *GetSchoolForSectionNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get school for section not found response has a 5xx status code
+func (o *GetSchoolForSectionNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get school for section not found response a status code equal to that given
+func (o *GetSchoolForSectionNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get school for section not found response
+func (o *GetSchoolForSectionNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSchoolForSectionNotFound) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/school][%d] getSchoolForSectionNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSchoolForSectionNotFound) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/school][%d] getSchoolForSectionNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSchoolForSectionNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/sections/get_section_parameters.go
+++ b/client/sections/get_section_parameters.go
@@ -52,10 +52,12 @@ func NewGetSectionParamsWithHTTPClient(client *http.Client) *GetSectionParams {
 	}
 }
 
-/* GetSectionParams contains all the parameters to send to the API endpoint
-   for the get section operation.
+/*
+GetSectionParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get section operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSectionParams struct {
 

--- a/client/sections/get_section_responses.go
+++ b/client/sections/get_section_responses.go
@@ -36,7 +36,7 @@ func (o *GetSectionReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections/{id}] getSection", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSectionOK() *GetSectionOK {
 	return &GetSectionOK{}
 }
 
-/* GetSectionOK describes a response with status code 200, with default header values.
+/*
+GetSectionOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSectionOK struct {
 	Payload *models.SectionResponse
 }
 
+// IsSuccess returns true when this get section o k response has a 2xx status code
+func (o *GetSectionOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get section o k response has a 3xx status code
+func (o *GetSectionOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get section o k response has a 4xx status code
+func (o *GetSectionOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get section o k response has a 5xx status code
+func (o *GetSectionOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get section o k response a status code equal to that given
+func (o *GetSectionOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get section o k response
+func (o *GetSectionOK) Code() int {
+	return 200
+}
+
 func (o *GetSectionOK) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}][%d] getSectionOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSectionOK) String() string {
+	return fmt.Sprintf("[GET /sections/{id}][%d] getSectionOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSectionOK) GetPayload() *models.SectionResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSectionNotFound() *GetSectionNotFound {
 	return &GetSectionNotFound{}
 }
 
-/* GetSectionNotFound describes a response with status code 404, with default header values.
+/*
+GetSectionNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSectionNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get section not found response has a 2xx status code
+func (o *GetSectionNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get section not found response has a 3xx status code
+func (o *GetSectionNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get section not found response has a 4xx status code
+func (o *GetSectionNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get section not found response has a 5xx status code
+func (o *GetSectionNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get section not found response a status code equal to that given
+func (o *GetSectionNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get section not found response
+func (o *GetSectionNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSectionNotFound) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}][%d] getSectionNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSectionNotFound) String() string {
+	return fmt.Sprintf("[GET /sections/{id}][%d] getSectionNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSectionNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/sections/get_sections_parameters.go
+++ b/client/sections/get_sections_parameters.go
@@ -53,10 +53,12 @@ func NewGetSectionsParamsWithHTTPClient(client *http.Client) *GetSectionsParams 
 	}
 }
 
-/* GetSectionsParams contains all the parameters to send to the API endpoint
-   for the get sections operation.
+/*
+GetSectionsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get sections operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSectionsParams struct {
 

--- a/client/sections/get_sections_responses.go
+++ b/client/sections/get_sections_responses.go
@@ -30,7 +30,7 @@ func (o *GetSectionsReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections] getSections", response, response.Code())
 	}
 }
 
@@ -39,7 +39,8 @@ func NewGetSectionsOK() *GetSectionsOK {
 	return &GetSectionsOK{}
 }
 
-/* GetSectionsOK describes a response with status code 200, with default header values.
+/*
+GetSectionsOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -47,9 +48,44 @@ type GetSectionsOK struct {
 	Payload *models.SectionsResponse
 }
 
+// IsSuccess returns true when this get sections o k response has a 2xx status code
+func (o *GetSectionsOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get sections o k response has a 3xx status code
+func (o *GetSectionsOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections o k response has a 4xx status code
+func (o *GetSectionsOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get sections o k response has a 5xx status code
+func (o *GetSectionsOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections o k response a status code equal to that given
+func (o *GetSectionsOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get sections o k response
+func (o *GetSectionsOK) Code() int {
+	return 200
+}
+
 func (o *GetSectionsOK) Error() string {
 	return fmt.Sprintf("[GET /sections][%d] getSectionsOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSectionsOK) String() string {
+	return fmt.Sprintf("[GET /sections][%d] getSectionsOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSectionsOK) GetPayload() *models.SectionsResponse {
 	return o.Payload
 }

--- a/client/sections/get_term_for_section_parameters.go
+++ b/client/sections/get_term_for_section_parameters.go
@@ -52,10 +52,12 @@ func NewGetTermForSectionParamsWithHTTPClient(client *http.Client) *GetTermForSe
 	}
 }
 
-/* GetTermForSectionParams contains all the parameters to send to the API endpoint
-   for the get term for section operation.
+/*
+GetTermForSectionParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get term for section operation.
+
+	Typically these are written to a http.Request.
 */
 type GetTermForSectionParams struct {
 

--- a/client/sections/get_term_for_section_responses.go
+++ b/client/sections/get_term_for_section_responses.go
@@ -36,7 +36,7 @@ func (o *GetTermForSectionReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections/{id}/term] getTermForSection", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetTermForSectionOK() *GetTermForSectionOK {
 	return &GetTermForSectionOK{}
 }
 
-/* GetTermForSectionOK describes a response with status code 200, with default header values.
+/*
+GetTermForSectionOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetTermForSectionOK struct {
 	Payload *models.TermResponse
 }
 
+// IsSuccess returns true when this get term for section o k response has a 2xx status code
+func (o *GetTermForSectionOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get term for section o k response has a 3xx status code
+func (o *GetTermForSectionOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get term for section o k response has a 4xx status code
+func (o *GetTermForSectionOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get term for section o k response has a 5xx status code
+func (o *GetTermForSectionOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get term for section o k response a status code equal to that given
+func (o *GetTermForSectionOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get term for section o k response
+func (o *GetTermForSectionOK) Code() int {
+	return 200
+}
+
 func (o *GetTermForSectionOK) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/term][%d] getTermForSectionOK  %+v", 200, o.Payload)
 }
+
+func (o *GetTermForSectionOK) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/term][%d] getTermForSectionOK  %+v", 200, o.Payload)
+}
+
 func (o *GetTermForSectionOK) GetPayload() *models.TermResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetTermForSectionNotFound() *GetTermForSectionNotFound {
 	return &GetTermForSectionNotFound{}
 }
 
-/* GetTermForSectionNotFound describes a response with status code 404, with default header values.
+/*
+GetTermForSectionNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetTermForSectionNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get term for section not found response has a 2xx status code
+func (o *GetTermForSectionNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get term for section not found response has a 3xx status code
+func (o *GetTermForSectionNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get term for section not found response has a 4xx status code
+func (o *GetTermForSectionNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get term for section not found response has a 5xx status code
+func (o *GetTermForSectionNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get term for section not found response a status code equal to that given
+func (o *GetTermForSectionNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get term for section not found response
+func (o *GetTermForSectionNotFound) Code() int {
+	return 404
+}
+
 func (o *GetTermForSectionNotFound) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/term][%d] getTermForSectionNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetTermForSectionNotFound) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/term][%d] getTermForSectionNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetTermForSectionNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/sections/get_users_for_section_parameters.go
+++ b/client/sections/get_users_for_section_parameters.go
@@ -53,10 +53,12 @@ func NewGetUsersForSectionParamsWithHTTPClient(client *http.Client) *GetUsersFor
 	}
 }
 
-/* GetUsersForSectionParams contains all the parameters to send to the API endpoint
-   for the get users for section operation.
+/*
+GetUsersForSectionParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get users for section operation.
+
+	Typically these are written to a http.Request.
 */
 type GetUsersForSectionParams struct {
 

--- a/client/sections/get_users_for_section_responses.go
+++ b/client/sections/get_users_for_section_responses.go
@@ -36,7 +36,7 @@ func (o *GetUsersForSectionReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /sections/{id}/users] getUsersForSection", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetUsersForSectionOK() *GetUsersForSectionOK {
 	return &GetUsersForSectionOK{}
 }
 
-/* GetUsersForSectionOK describes a response with status code 200, with default header values.
+/*
+GetUsersForSectionOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetUsersForSectionOK struct {
 	Payload *models.UsersResponse
 }
 
+// IsSuccess returns true when this get users for section o k response has a 2xx status code
+func (o *GetUsersForSectionOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get users for section o k response has a 3xx status code
+func (o *GetUsersForSectionOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get users for section o k response has a 4xx status code
+func (o *GetUsersForSectionOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get users for section o k response has a 5xx status code
+func (o *GetUsersForSectionOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get users for section o k response a status code equal to that given
+func (o *GetUsersForSectionOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get users for section o k response
+func (o *GetUsersForSectionOK) Code() int {
+	return 200
+}
+
 func (o *GetUsersForSectionOK) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/users][%d] getUsersForSectionOK  %+v", 200, o.Payload)
 }
+
+func (o *GetUsersForSectionOK) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/users][%d] getUsersForSectionOK  %+v", 200, o.Payload)
+}
+
 func (o *GetUsersForSectionOK) GetPayload() *models.UsersResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetUsersForSectionNotFound() *GetUsersForSectionNotFound {
 	return &GetUsersForSectionNotFound{}
 }
 
-/* GetUsersForSectionNotFound describes a response with status code 404, with default header values.
+/*
+GetUsersForSectionNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetUsersForSectionNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get users for section not found response has a 2xx status code
+func (o *GetUsersForSectionNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get users for section not found response has a 3xx status code
+func (o *GetUsersForSectionNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get users for section not found response has a 4xx status code
+func (o *GetUsersForSectionNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get users for section not found response has a 5xx status code
+func (o *GetUsersForSectionNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get users for section not found response a status code equal to that given
+func (o *GetUsersForSectionNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get users for section not found response
+func (o *GetUsersForSectionNotFound) Code() int {
+	return 404
+}
+
 func (o *GetUsersForSectionNotFound) Error() string {
 	return fmt.Sprintf("[GET /sections/{id}/users][%d] getUsersForSectionNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetUsersForSectionNotFound) String() string {
+	return fmt.Sprintf("[GET /sections/{id}/users][%d] getUsersForSectionNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetUsersForSectionNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/sections/sections_client.go
+++ b/client/sections/sections_client.go
@@ -50,7 +50,7 @@ type ClientService interface {
 }
 
 /*
-  GetCourseForSection Returns the course for a section
+GetCourseForSection Returns the course for a section
 */
 func (a *Client) GetCourseForSection(params *GetCourseForSectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetCourseForSectionOK, error) {
 	// TODO: Validate the params before sending
@@ -89,7 +89,7 @@ func (a *Client) GetCourseForSection(params *GetCourseForSectionParams, authInfo
 }
 
 /*
-  GetDistrictForSection Returns the district for a section
+GetDistrictForSection Returns the district for a section
 */
 func (a *Client) GetDistrictForSection(params *GetDistrictForSectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetDistrictForSectionOK, error) {
 	// TODO: Validate the params before sending
@@ -128,7 +128,7 @@ func (a *Client) GetDistrictForSection(params *GetDistrictForSectionParams, auth
 }
 
 /*
-  GetResourcesForSection Returns the resources for a section
+GetResourcesForSection Returns the resources for a section
 */
 func (a *Client) GetResourcesForSection(params *GetResourcesForSectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetResourcesForSectionOK, error) {
 	// TODO: Validate the params before sending
@@ -167,7 +167,7 @@ func (a *Client) GetResourcesForSection(params *GetResourcesForSectionParams, au
 }
 
 /*
-  GetSchoolForSection Returns the school for a section
+GetSchoolForSection Returns the school for a section
 */
 func (a *Client) GetSchoolForSection(params *GetSchoolForSectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSchoolForSectionOK, error) {
 	// TODO: Validate the params before sending
@@ -206,7 +206,7 @@ func (a *Client) GetSchoolForSection(params *GetSchoolForSectionParams, authInfo
 }
 
 /*
-  GetSection Returns a specific section
+GetSection Returns a specific section
 */
 func (a *Client) GetSection(params *GetSectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSectionOK, error) {
 	// TODO: Validate the params before sending
@@ -245,7 +245,7 @@ func (a *Client) GetSection(params *GetSectionParams, authInfo runtime.ClientAut
 }
 
 /*
-  GetSections Returns a list of sections
+GetSections Returns a list of sections
 */
 func (a *Client) GetSections(params *GetSectionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSectionsOK, error) {
 	// TODO: Validate the params before sending
@@ -284,7 +284,7 @@ func (a *Client) GetSections(params *GetSectionsParams, authInfo runtime.ClientA
 }
 
 /*
-  GetTermForSection Returns the term for a section
+GetTermForSection Returns the term for a section
 */
 func (a *Client) GetTermForSection(params *GetTermForSectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetTermForSectionOK, error) {
 	// TODO: Validate the params before sending
@@ -323,7 +323,7 @@ func (a *Client) GetTermForSection(params *GetTermForSectionParams, authInfo run
 }
 
 /*
-  GetUsersForSection Returns the student and/or teacher users for a section
+GetUsersForSection Returns the student and/or teacher users for a section
 */
 func (a *Client) GetUsersForSection(params *GetUsersForSectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersForSectionOK, error) {
 	// TODO: Validate the params before sending

--- a/client/terms/get_district_for_term_parameters.go
+++ b/client/terms/get_district_for_term_parameters.go
@@ -52,10 +52,12 @@ func NewGetDistrictForTermParamsWithHTTPClient(client *http.Client) *GetDistrict
 	}
 }
 
-/* GetDistrictForTermParams contains all the parameters to send to the API endpoint
-   for the get district for term operation.
+/*
+GetDistrictForTermParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get district for term operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDistrictForTermParams struct {
 

--- a/client/terms/get_district_for_term_responses.go
+++ b/client/terms/get_district_for_term_responses.go
@@ -36,7 +36,7 @@ func (o *GetDistrictForTermReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /terms/{id}/district] getDistrictForTerm", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetDistrictForTermOK() *GetDistrictForTermOK {
 	return &GetDistrictForTermOK{}
 }
 
-/* GetDistrictForTermOK describes a response with status code 200, with default header values.
+/*
+GetDistrictForTermOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetDistrictForTermOK struct {
 	Payload *models.DistrictResponse
 }
 
+// IsSuccess returns true when this get district for term o k response has a 2xx status code
+func (o *GetDistrictForTermOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get district for term o k response has a 3xx status code
+func (o *GetDistrictForTermOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for term o k response has a 4xx status code
+func (o *GetDistrictForTermOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get district for term o k response has a 5xx status code
+func (o *GetDistrictForTermOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for term o k response a status code equal to that given
+func (o *GetDistrictForTermOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get district for term o k response
+func (o *GetDistrictForTermOK) Code() int {
+	return 200
+}
+
 func (o *GetDistrictForTermOK) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}/district][%d] getDistrictForTermOK  %+v", 200, o.Payload)
 }
+
+func (o *GetDistrictForTermOK) String() string {
+	return fmt.Sprintf("[GET /terms/{id}/district][%d] getDistrictForTermOK  %+v", 200, o.Payload)
+}
+
 func (o *GetDistrictForTermOK) GetPayload() *models.DistrictResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetDistrictForTermNotFound() *GetDistrictForTermNotFound {
 	return &GetDistrictForTermNotFound{}
 }
 
-/* GetDistrictForTermNotFound describes a response with status code 404, with default header values.
+/*
+GetDistrictForTermNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetDistrictForTermNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get district for term not found response has a 2xx status code
+func (o *GetDistrictForTermNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get district for term not found response has a 3xx status code
+func (o *GetDistrictForTermNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for term not found response has a 4xx status code
+func (o *GetDistrictForTermNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get district for term not found response has a 5xx status code
+func (o *GetDistrictForTermNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for term not found response a status code equal to that given
+func (o *GetDistrictForTermNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get district for term not found response
+func (o *GetDistrictForTermNotFound) Code() int {
+	return 404
+}
+
 func (o *GetDistrictForTermNotFound) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}/district][%d] getDistrictForTermNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetDistrictForTermNotFound) String() string {
+	return fmt.Sprintf("[GET /terms/{id}/district][%d] getDistrictForTermNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetDistrictForTermNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/terms/get_schools_for_term_parameters.go
+++ b/client/terms/get_schools_for_term_parameters.go
@@ -53,10 +53,12 @@ func NewGetSchoolsForTermParamsWithHTTPClient(client *http.Client) *GetSchoolsFo
 	}
 }
 
-/* GetSchoolsForTermParams contains all the parameters to send to the API endpoint
-   for the get schools for term operation.
+/*
+GetSchoolsForTermParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get schools for term operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSchoolsForTermParams struct {
 

--- a/client/terms/get_schools_for_term_responses.go
+++ b/client/terms/get_schools_for_term_responses.go
@@ -36,7 +36,7 @@ func (o *GetSchoolsForTermReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /terms/{id}/schools] getSchoolsForTerm", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSchoolsForTermOK() *GetSchoolsForTermOK {
 	return &GetSchoolsForTermOK{}
 }
 
-/* GetSchoolsForTermOK describes a response with status code 200, with default header values.
+/*
+GetSchoolsForTermOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSchoolsForTermOK struct {
 	Payload *models.SchoolsResponse
 }
 
+// IsSuccess returns true when this get schools for term o k response has a 2xx status code
+func (o *GetSchoolsForTermOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get schools for term o k response has a 3xx status code
+func (o *GetSchoolsForTermOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get schools for term o k response has a 4xx status code
+func (o *GetSchoolsForTermOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get schools for term o k response has a 5xx status code
+func (o *GetSchoolsForTermOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get schools for term o k response a status code equal to that given
+func (o *GetSchoolsForTermOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get schools for term o k response
+func (o *GetSchoolsForTermOK) Code() int {
+	return 200
+}
+
 func (o *GetSchoolsForTermOK) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}/schools][%d] getSchoolsForTermOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSchoolsForTermOK) String() string {
+	return fmt.Sprintf("[GET /terms/{id}/schools][%d] getSchoolsForTermOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSchoolsForTermOK) GetPayload() *models.SchoolsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSchoolsForTermNotFound() *GetSchoolsForTermNotFound {
 	return &GetSchoolsForTermNotFound{}
 }
 
-/* GetSchoolsForTermNotFound describes a response with status code 404, with default header values.
+/*
+GetSchoolsForTermNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSchoolsForTermNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get schools for term not found response has a 2xx status code
+func (o *GetSchoolsForTermNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get schools for term not found response has a 3xx status code
+func (o *GetSchoolsForTermNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get schools for term not found response has a 4xx status code
+func (o *GetSchoolsForTermNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get schools for term not found response has a 5xx status code
+func (o *GetSchoolsForTermNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get schools for term not found response a status code equal to that given
+func (o *GetSchoolsForTermNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get schools for term not found response
+func (o *GetSchoolsForTermNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSchoolsForTermNotFound) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}/schools][%d] getSchoolsForTermNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSchoolsForTermNotFound) String() string {
+	return fmt.Sprintf("[GET /terms/{id}/schools][%d] getSchoolsForTermNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSchoolsForTermNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/terms/get_sections_for_term_parameters.go
+++ b/client/terms/get_sections_for_term_parameters.go
@@ -53,10 +53,12 @@ func NewGetSectionsForTermParamsWithHTTPClient(client *http.Client) *GetSections
 	}
 }
 
-/* GetSectionsForTermParams contains all the parameters to send to the API endpoint
-   for the get sections for term operation.
+/*
+GetSectionsForTermParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get sections for term operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSectionsForTermParams struct {
 

--- a/client/terms/get_sections_for_term_responses.go
+++ b/client/terms/get_sections_for_term_responses.go
@@ -36,7 +36,7 @@ func (o *GetSectionsForTermReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /terms/{id}/sections] getSectionsForTerm", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSectionsForTermOK() *GetSectionsForTermOK {
 	return &GetSectionsForTermOK{}
 }
 
-/* GetSectionsForTermOK describes a response with status code 200, with default header values.
+/*
+GetSectionsForTermOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSectionsForTermOK struct {
 	Payload *models.SectionsResponse
 }
 
+// IsSuccess returns true when this get sections for term o k response has a 2xx status code
+func (o *GetSectionsForTermOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get sections for term o k response has a 3xx status code
+func (o *GetSectionsForTermOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for term o k response has a 4xx status code
+func (o *GetSectionsForTermOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get sections for term o k response has a 5xx status code
+func (o *GetSectionsForTermOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for term o k response a status code equal to that given
+func (o *GetSectionsForTermOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get sections for term o k response
+func (o *GetSectionsForTermOK) Code() int {
+	return 200
+}
+
 func (o *GetSectionsForTermOK) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}/sections][%d] getSectionsForTermOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSectionsForTermOK) String() string {
+	return fmt.Sprintf("[GET /terms/{id}/sections][%d] getSectionsForTermOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSectionsForTermOK) GetPayload() *models.SectionsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSectionsForTermNotFound() *GetSectionsForTermNotFound {
 	return &GetSectionsForTermNotFound{}
 }
 
-/* GetSectionsForTermNotFound describes a response with status code 404, with default header values.
+/*
+GetSectionsForTermNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSectionsForTermNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get sections for term not found response has a 2xx status code
+func (o *GetSectionsForTermNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get sections for term not found response has a 3xx status code
+func (o *GetSectionsForTermNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for term not found response has a 4xx status code
+func (o *GetSectionsForTermNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get sections for term not found response has a 5xx status code
+func (o *GetSectionsForTermNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for term not found response a status code equal to that given
+func (o *GetSectionsForTermNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get sections for term not found response
+func (o *GetSectionsForTermNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSectionsForTermNotFound) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}/sections][%d] getSectionsForTermNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSectionsForTermNotFound) String() string {
+	return fmt.Sprintf("[GET /terms/{id}/sections][%d] getSectionsForTermNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSectionsForTermNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/terms/get_term_parameters.go
+++ b/client/terms/get_term_parameters.go
@@ -52,10 +52,12 @@ func NewGetTermParamsWithHTTPClient(client *http.Client) *GetTermParams {
 	}
 }
 
-/* GetTermParams contains all the parameters to send to the API endpoint
-   for the get term operation.
+/*
+GetTermParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get term operation.
+
+	Typically these are written to a http.Request.
 */
 type GetTermParams struct {
 

--- a/client/terms/get_term_responses.go
+++ b/client/terms/get_term_responses.go
@@ -36,7 +36,7 @@ func (o *GetTermReader) ReadResponse(response runtime.ClientResponse, consumer r
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /terms/{id}] getTerm", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetTermOK() *GetTermOK {
 	return &GetTermOK{}
 }
 
-/* GetTermOK describes a response with status code 200, with default header values.
+/*
+GetTermOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetTermOK struct {
 	Payload *models.TermResponse
 }
 
+// IsSuccess returns true when this get term o k response has a 2xx status code
+func (o *GetTermOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get term o k response has a 3xx status code
+func (o *GetTermOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get term o k response has a 4xx status code
+func (o *GetTermOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get term o k response has a 5xx status code
+func (o *GetTermOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get term o k response a status code equal to that given
+func (o *GetTermOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get term o k response
+func (o *GetTermOK) Code() int {
+	return 200
+}
+
 func (o *GetTermOK) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}][%d] getTermOK  %+v", 200, o.Payload)
 }
+
+func (o *GetTermOK) String() string {
+	return fmt.Sprintf("[GET /terms/{id}][%d] getTermOK  %+v", 200, o.Payload)
+}
+
 func (o *GetTermOK) GetPayload() *models.TermResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetTermNotFound() *GetTermNotFound {
 	return &GetTermNotFound{}
 }
 
-/* GetTermNotFound describes a response with status code 404, with default header values.
+/*
+GetTermNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetTermNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get term not found response has a 2xx status code
+func (o *GetTermNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get term not found response has a 3xx status code
+func (o *GetTermNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get term not found response has a 4xx status code
+func (o *GetTermNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get term not found response has a 5xx status code
+func (o *GetTermNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get term not found response a status code equal to that given
+func (o *GetTermNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get term not found response
+func (o *GetTermNotFound) Code() int {
+	return 404
+}
+
 func (o *GetTermNotFound) Error() string {
 	return fmt.Sprintf("[GET /terms/{id}][%d] getTermNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetTermNotFound) String() string {
+	return fmt.Sprintf("[GET /terms/{id}][%d] getTermNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetTermNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/terms/get_terms_parameters.go
+++ b/client/terms/get_terms_parameters.go
@@ -53,10 +53,12 @@ func NewGetTermsParamsWithHTTPClient(client *http.Client) *GetTermsParams {
 	}
 }
 
-/* GetTermsParams contains all the parameters to send to the API endpoint
-   for the get terms operation.
+/*
+GetTermsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get terms operation.
+
+	Typically these are written to a http.Request.
 */
 type GetTermsParams struct {
 

--- a/client/terms/get_terms_responses.go
+++ b/client/terms/get_terms_responses.go
@@ -30,7 +30,7 @@ func (o *GetTermsReader) ReadResponse(response runtime.ClientResponse, consumer 
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /terms] getTerms", response, response.Code())
 	}
 }
 
@@ -39,7 +39,8 @@ func NewGetTermsOK() *GetTermsOK {
 	return &GetTermsOK{}
 }
 
-/* GetTermsOK describes a response with status code 200, with default header values.
+/*
+GetTermsOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -47,9 +48,44 @@ type GetTermsOK struct {
 	Payload *models.TermsResponse
 }
 
+// IsSuccess returns true when this get terms o k response has a 2xx status code
+func (o *GetTermsOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get terms o k response has a 3xx status code
+func (o *GetTermsOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get terms o k response has a 4xx status code
+func (o *GetTermsOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get terms o k response has a 5xx status code
+func (o *GetTermsOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get terms o k response a status code equal to that given
+func (o *GetTermsOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get terms o k response
+func (o *GetTermsOK) Code() int {
+	return 200
+}
+
 func (o *GetTermsOK) Error() string {
 	return fmt.Sprintf("[GET /terms][%d] getTermsOK  %+v", 200, o.Payload)
 }
+
+func (o *GetTermsOK) String() string {
+	return fmt.Sprintf("[GET /terms][%d] getTermsOK  %+v", 200, o.Payload)
+}
+
 func (o *GetTermsOK) GetPayload() *models.TermsResponse {
 	return o.Payload
 }

--- a/client/terms/terms_client.go
+++ b/client/terms/terms_client.go
@@ -44,7 +44,7 @@ type ClientService interface {
 }
 
 /*
-  GetDistrictForTerm Returns the district for a term
+GetDistrictForTerm Returns the district for a term
 */
 func (a *Client) GetDistrictForTerm(params *GetDistrictForTermParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetDistrictForTermOK, error) {
 	// TODO: Validate the params before sending
@@ -83,7 +83,7 @@ func (a *Client) GetDistrictForTerm(params *GetDistrictForTermParams, authInfo r
 }
 
 /*
-  GetSchoolsForTerm Returns the schools for a term
+GetSchoolsForTerm Returns the schools for a term
 */
 func (a *Client) GetSchoolsForTerm(params *GetSchoolsForTermParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSchoolsForTermOK, error) {
 	// TODO: Validate the params before sending
@@ -122,7 +122,7 @@ func (a *Client) GetSchoolsForTerm(params *GetSchoolsForTermParams, authInfo run
 }
 
 /*
-  GetSectionsForTerm Returns the sections for a term
+GetSectionsForTerm Returns the sections for a term
 */
 func (a *Client) GetSectionsForTerm(params *GetSectionsForTermParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSectionsForTermOK, error) {
 	// TODO: Validate the params before sending
@@ -161,7 +161,7 @@ func (a *Client) GetSectionsForTerm(params *GetSectionsForTermParams, authInfo r
 }
 
 /*
-  GetTerm Returns a specific term
+GetTerm Returns a specific term
 */
 func (a *Client) GetTerm(params *GetTermParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetTermOK, error) {
 	// TODO: Validate the params before sending
@@ -200,7 +200,7 @@ func (a *Client) GetTerm(params *GetTermParams, authInfo runtime.ClientAuthInfoW
 }
 
 /*
-  GetTerms Returns a list of terms
+GetTerms Returns a list of terms
 */
 func (a *Client) GetTerms(params *GetTermsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetTermsOK, error) {
 	// TODO: Validate the params before sending

--- a/client/users/get_contacts_for_user_parameters.go
+++ b/client/users/get_contacts_for_user_parameters.go
@@ -53,10 +53,12 @@ func NewGetContactsForUserParamsWithHTTPClient(client *http.Client) *GetContacts
 	}
 }
 
-/* GetContactsForUserParams contains all the parameters to send to the API endpoint
-   for the get contacts for user operation.
+/*
+GetContactsForUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get contacts for user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetContactsForUserParams struct {
 

--- a/client/users/get_contacts_for_user_responses.go
+++ b/client/users/get_contacts_for_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetContactsForUserReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}/mycontacts] getContactsForUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetContactsForUserOK() *GetContactsForUserOK {
 	return &GetContactsForUserOK{}
 }
 
-/* GetContactsForUserOK describes a response with status code 200, with default header values.
+/*
+GetContactsForUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetContactsForUserOK struct {
 	Payload *models.UsersResponse
 }
 
+// IsSuccess returns true when this get contacts for user o k response has a 2xx status code
+func (o *GetContactsForUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get contacts for user o k response has a 3xx status code
+func (o *GetContactsForUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get contacts for user o k response has a 4xx status code
+func (o *GetContactsForUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get contacts for user o k response has a 5xx status code
+func (o *GetContactsForUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get contacts for user o k response a status code equal to that given
+func (o *GetContactsForUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get contacts for user o k response
+func (o *GetContactsForUserOK) Code() int {
+	return 200
+}
+
 func (o *GetContactsForUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/mycontacts][%d] getContactsForUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetContactsForUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}/mycontacts][%d] getContactsForUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetContactsForUserOK) GetPayload() *models.UsersResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetContactsForUserNotFound() *GetContactsForUserNotFound {
 	return &GetContactsForUserNotFound{}
 }
 
-/* GetContactsForUserNotFound describes a response with status code 404, with default header values.
+/*
+GetContactsForUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetContactsForUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get contacts for user not found response has a 2xx status code
+func (o *GetContactsForUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get contacts for user not found response has a 3xx status code
+func (o *GetContactsForUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get contacts for user not found response has a 4xx status code
+func (o *GetContactsForUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get contacts for user not found response has a 5xx status code
+func (o *GetContactsForUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get contacts for user not found response a status code equal to that given
+func (o *GetContactsForUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get contacts for user not found response
+func (o *GetContactsForUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetContactsForUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/mycontacts][%d] getContactsForUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetContactsForUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}/mycontacts][%d] getContactsForUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetContactsForUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_district_for_user_parameters.go
+++ b/client/users/get_district_for_user_parameters.go
@@ -52,10 +52,12 @@ func NewGetDistrictForUserParamsWithHTTPClient(client *http.Client) *GetDistrict
 	}
 }
 
-/* GetDistrictForUserParams contains all the parameters to send to the API endpoint
-   for the get district for user operation.
+/*
+GetDistrictForUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get district for user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDistrictForUserParams struct {
 

--- a/client/users/get_district_for_user_responses.go
+++ b/client/users/get_district_for_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetDistrictForUserReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}/district] getDistrictForUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetDistrictForUserOK() *GetDistrictForUserOK {
 	return &GetDistrictForUserOK{}
 }
 
-/* GetDistrictForUserOK describes a response with status code 200, with default header values.
+/*
+GetDistrictForUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetDistrictForUserOK struct {
 	Payload *models.DistrictResponse
 }
 
+// IsSuccess returns true when this get district for user o k response has a 2xx status code
+func (o *GetDistrictForUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get district for user o k response has a 3xx status code
+func (o *GetDistrictForUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for user o k response has a 4xx status code
+func (o *GetDistrictForUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get district for user o k response has a 5xx status code
+func (o *GetDistrictForUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for user o k response a status code equal to that given
+func (o *GetDistrictForUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get district for user o k response
+func (o *GetDistrictForUserOK) Code() int {
+	return 200
+}
+
 func (o *GetDistrictForUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/district][%d] getDistrictForUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetDistrictForUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}/district][%d] getDistrictForUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetDistrictForUserOK) GetPayload() *models.DistrictResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetDistrictForUserNotFound() *GetDistrictForUserNotFound {
 	return &GetDistrictForUserNotFound{}
 }
 
-/* GetDistrictForUserNotFound describes a response with status code 404, with default header values.
+/*
+GetDistrictForUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetDistrictForUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get district for user not found response has a 2xx status code
+func (o *GetDistrictForUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get district for user not found response has a 3xx status code
+func (o *GetDistrictForUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get district for user not found response has a 4xx status code
+func (o *GetDistrictForUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get district for user not found response has a 5xx status code
+func (o *GetDistrictForUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get district for user not found response a status code equal to that given
+func (o *GetDistrictForUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get district for user not found response
+func (o *GetDistrictForUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetDistrictForUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/district][%d] getDistrictForUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetDistrictForUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}/district][%d] getDistrictForUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetDistrictForUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_resources_for_user_parameters.go
+++ b/client/users/get_resources_for_user_parameters.go
@@ -53,10 +53,12 @@ func NewGetResourcesForUserParamsWithHTTPClient(client *http.Client) *GetResourc
 	}
 }
 
-/* GetResourcesForUserParams contains all the parameters to send to the API endpoint
-   for the get resources for user operation.
+/*
+GetResourcesForUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get resources for user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetResourcesForUserParams struct {
 

--- a/client/users/get_resources_for_user_responses.go
+++ b/client/users/get_resources_for_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetResourcesForUserReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}/resources] getResourcesForUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetResourcesForUserOK() *GetResourcesForUserOK {
 	return &GetResourcesForUserOK{}
 }
 
-/* GetResourcesForUserOK describes a response with status code 200, with default header values.
+/*
+GetResourcesForUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetResourcesForUserOK struct {
 	Payload *models.ResourcesResponse
 }
 
+// IsSuccess returns true when this get resources for user o k response has a 2xx status code
+func (o *GetResourcesForUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get resources for user o k response has a 3xx status code
+func (o *GetResourcesForUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resources for user o k response has a 4xx status code
+func (o *GetResourcesForUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get resources for user o k response has a 5xx status code
+func (o *GetResourcesForUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resources for user o k response a status code equal to that given
+func (o *GetResourcesForUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get resources for user o k response
+func (o *GetResourcesForUserOK) Code() int {
+	return 200
+}
+
 func (o *GetResourcesForUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/resources][%d] getResourcesForUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetResourcesForUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}/resources][%d] getResourcesForUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetResourcesForUserOK) GetPayload() *models.ResourcesResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetResourcesForUserNotFound() *GetResourcesForUserNotFound {
 	return &GetResourcesForUserNotFound{}
 }
 
-/* GetResourcesForUserNotFound describes a response with status code 404, with default header values.
+/*
+GetResourcesForUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetResourcesForUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get resources for user not found response has a 2xx status code
+func (o *GetResourcesForUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get resources for user not found response has a 3xx status code
+func (o *GetResourcesForUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get resources for user not found response has a 4xx status code
+func (o *GetResourcesForUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get resources for user not found response has a 5xx status code
+func (o *GetResourcesForUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get resources for user not found response a status code equal to that given
+func (o *GetResourcesForUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get resources for user not found response
+func (o *GetResourcesForUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetResourcesForUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/resources][%d] getResourcesForUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetResourcesForUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}/resources][%d] getResourcesForUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetResourcesForUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_schools_for_user_parameters.go
+++ b/client/users/get_schools_for_user_parameters.go
@@ -53,10 +53,12 @@ func NewGetSchoolsForUserParamsWithHTTPClient(client *http.Client) *GetSchoolsFo
 	}
 }
 
-/* GetSchoolsForUserParams contains all the parameters to send to the API endpoint
-   for the get schools for user operation.
+/*
+GetSchoolsForUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get schools for user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSchoolsForUserParams struct {
 

--- a/client/users/get_schools_for_user_responses.go
+++ b/client/users/get_schools_for_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetSchoolsForUserReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}/schools] getSchoolsForUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSchoolsForUserOK() *GetSchoolsForUserOK {
 	return &GetSchoolsForUserOK{}
 }
 
-/* GetSchoolsForUserOK describes a response with status code 200, with default header values.
+/*
+GetSchoolsForUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSchoolsForUserOK struct {
 	Payload *models.SchoolsResponse
 }
 
+// IsSuccess returns true when this get schools for user o k response has a 2xx status code
+func (o *GetSchoolsForUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get schools for user o k response has a 3xx status code
+func (o *GetSchoolsForUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get schools for user o k response has a 4xx status code
+func (o *GetSchoolsForUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get schools for user o k response has a 5xx status code
+func (o *GetSchoolsForUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get schools for user o k response a status code equal to that given
+func (o *GetSchoolsForUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get schools for user o k response
+func (o *GetSchoolsForUserOK) Code() int {
+	return 200
+}
+
 func (o *GetSchoolsForUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/schools][%d] getSchoolsForUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSchoolsForUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}/schools][%d] getSchoolsForUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSchoolsForUserOK) GetPayload() *models.SchoolsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSchoolsForUserNotFound() *GetSchoolsForUserNotFound {
 	return &GetSchoolsForUserNotFound{}
 }
 
-/* GetSchoolsForUserNotFound describes a response with status code 404, with default header values.
+/*
+GetSchoolsForUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSchoolsForUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get schools for user not found response has a 2xx status code
+func (o *GetSchoolsForUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get schools for user not found response has a 3xx status code
+func (o *GetSchoolsForUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get schools for user not found response has a 4xx status code
+func (o *GetSchoolsForUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get schools for user not found response has a 5xx status code
+func (o *GetSchoolsForUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get schools for user not found response a status code equal to that given
+func (o *GetSchoolsForUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get schools for user not found response
+func (o *GetSchoolsForUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSchoolsForUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/schools][%d] getSchoolsForUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSchoolsForUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}/schools][%d] getSchoolsForUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSchoolsForUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_sections_for_user_parameters.go
+++ b/client/users/get_sections_for_user_parameters.go
@@ -53,10 +53,12 @@ func NewGetSectionsForUserParamsWithHTTPClient(client *http.Client) *GetSections
 	}
 }
 
-/* GetSectionsForUserParams contains all the parameters to send to the API endpoint
-   for the get sections for user operation.
+/*
+GetSectionsForUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get sections for user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetSectionsForUserParams struct {
 

--- a/client/users/get_sections_for_user_responses.go
+++ b/client/users/get_sections_for_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetSectionsForUserReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}/sections] getSectionsForUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetSectionsForUserOK() *GetSectionsForUserOK {
 	return &GetSectionsForUserOK{}
 }
 
-/* GetSectionsForUserOK describes a response with status code 200, with default header values.
+/*
+GetSectionsForUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetSectionsForUserOK struct {
 	Payload *models.SectionsResponse
 }
 
+// IsSuccess returns true when this get sections for user o k response has a 2xx status code
+func (o *GetSectionsForUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get sections for user o k response has a 3xx status code
+func (o *GetSectionsForUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for user o k response has a 4xx status code
+func (o *GetSectionsForUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get sections for user o k response has a 5xx status code
+func (o *GetSectionsForUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for user o k response a status code equal to that given
+func (o *GetSectionsForUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get sections for user o k response
+func (o *GetSectionsForUserOK) Code() int {
+	return 200
+}
+
 func (o *GetSectionsForUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/sections][%d] getSectionsForUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetSectionsForUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}/sections][%d] getSectionsForUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetSectionsForUserOK) GetPayload() *models.SectionsResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetSectionsForUserNotFound() *GetSectionsForUserNotFound {
 	return &GetSectionsForUserNotFound{}
 }
 
-/* GetSectionsForUserNotFound describes a response with status code 404, with default header values.
+/*
+GetSectionsForUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetSectionsForUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get sections for user not found response has a 2xx status code
+func (o *GetSectionsForUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get sections for user not found response has a 3xx status code
+func (o *GetSectionsForUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get sections for user not found response has a 4xx status code
+func (o *GetSectionsForUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get sections for user not found response has a 5xx status code
+func (o *GetSectionsForUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get sections for user not found response a status code equal to that given
+func (o *GetSectionsForUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get sections for user not found response
+func (o *GetSectionsForUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSectionsForUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/sections][%d] getSectionsForUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetSectionsForUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}/sections][%d] getSectionsForUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetSectionsForUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_students_for_user_parameters.go
+++ b/client/users/get_students_for_user_parameters.go
@@ -53,10 +53,12 @@ func NewGetStudentsForUserParamsWithHTTPClient(client *http.Client) *GetStudents
 	}
 }
 
-/* GetStudentsForUserParams contains all the parameters to send to the API endpoint
-   for the get students for user operation.
+/*
+GetStudentsForUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get students for user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetStudentsForUserParams struct {
 

--- a/client/users/get_students_for_user_responses.go
+++ b/client/users/get_students_for_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetStudentsForUserReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}/mystudents] getStudentsForUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetStudentsForUserOK() *GetStudentsForUserOK {
 	return &GetStudentsForUserOK{}
 }
 
-/* GetStudentsForUserOK describes a response with status code 200, with default header values.
+/*
+GetStudentsForUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetStudentsForUserOK struct {
 	Payload *models.UsersResponse
 }
 
+// IsSuccess returns true when this get students for user o k response has a 2xx status code
+func (o *GetStudentsForUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get students for user o k response has a 3xx status code
+func (o *GetStudentsForUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get students for user o k response has a 4xx status code
+func (o *GetStudentsForUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get students for user o k response has a 5xx status code
+func (o *GetStudentsForUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get students for user o k response a status code equal to that given
+func (o *GetStudentsForUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get students for user o k response
+func (o *GetStudentsForUserOK) Code() int {
+	return 200
+}
+
 func (o *GetStudentsForUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/mystudents][%d] getStudentsForUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetStudentsForUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}/mystudents][%d] getStudentsForUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetStudentsForUserOK) GetPayload() *models.UsersResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetStudentsForUserNotFound() *GetStudentsForUserNotFound {
 	return &GetStudentsForUserNotFound{}
 }
 
-/* GetStudentsForUserNotFound describes a response with status code 404, with default header values.
+/*
+GetStudentsForUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetStudentsForUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get students for user not found response has a 2xx status code
+func (o *GetStudentsForUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get students for user not found response has a 3xx status code
+func (o *GetStudentsForUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get students for user not found response has a 4xx status code
+func (o *GetStudentsForUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get students for user not found response has a 5xx status code
+func (o *GetStudentsForUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get students for user not found response a status code equal to that given
+func (o *GetStudentsForUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get students for user not found response
+func (o *GetStudentsForUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetStudentsForUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/mystudents][%d] getStudentsForUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetStudentsForUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}/mystudents][%d] getStudentsForUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetStudentsForUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_teachers_for_user_parameters.go
+++ b/client/users/get_teachers_for_user_parameters.go
@@ -53,10 +53,12 @@ func NewGetTeachersForUserParamsWithHTTPClient(client *http.Client) *GetTeachers
 	}
 }
 
-/* GetTeachersForUserParams contains all the parameters to send to the API endpoint
-   for the get teachers for user operation.
+/*
+GetTeachersForUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get teachers for user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetTeachersForUserParams struct {
 

--- a/client/users/get_teachers_for_user_responses.go
+++ b/client/users/get_teachers_for_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetTeachersForUserReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}/myteachers] getTeachersForUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetTeachersForUserOK() *GetTeachersForUserOK {
 	return &GetTeachersForUserOK{}
 }
 
-/* GetTeachersForUserOK describes a response with status code 200, with default header values.
+/*
+GetTeachersForUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetTeachersForUserOK struct {
 	Payload *models.UsersResponse
 }
 
+// IsSuccess returns true when this get teachers for user o k response has a 2xx status code
+func (o *GetTeachersForUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get teachers for user o k response has a 3xx status code
+func (o *GetTeachersForUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get teachers for user o k response has a 4xx status code
+func (o *GetTeachersForUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get teachers for user o k response has a 5xx status code
+func (o *GetTeachersForUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get teachers for user o k response a status code equal to that given
+func (o *GetTeachersForUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get teachers for user o k response
+func (o *GetTeachersForUserOK) Code() int {
+	return 200
+}
+
 func (o *GetTeachersForUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/myteachers][%d] getTeachersForUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetTeachersForUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}/myteachers][%d] getTeachersForUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetTeachersForUserOK) GetPayload() *models.UsersResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetTeachersForUserNotFound() *GetTeachersForUserNotFound {
 	return &GetTeachersForUserNotFound{}
 }
 
-/* GetTeachersForUserNotFound describes a response with status code 404, with default header values.
+/*
+GetTeachersForUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetTeachersForUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get teachers for user not found response has a 2xx status code
+func (o *GetTeachersForUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get teachers for user not found response has a 3xx status code
+func (o *GetTeachersForUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get teachers for user not found response has a 4xx status code
+func (o *GetTeachersForUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get teachers for user not found response has a 5xx status code
+func (o *GetTeachersForUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get teachers for user not found response a status code equal to that given
+func (o *GetTeachersForUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get teachers for user not found response
+func (o *GetTeachersForUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetTeachersForUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}/myteachers][%d] getTeachersForUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetTeachersForUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}/myteachers][%d] getTeachersForUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetTeachersForUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_user_parameters.go
+++ b/client/users/get_user_parameters.go
@@ -52,10 +52,12 @@ func NewGetUserParamsWithHTTPClient(client *http.Client) *GetUserParams {
 	}
 }
 
-/* GetUserParams contains all the parameters to send to the API endpoint
-   for the get user operation.
+/*
+GetUserParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get user operation.
+
+	Typically these are written to a http.Request.
 */
 type GetUserParams struct {
 

--- a/client/users/get_user_responses.go
+++ b/client/users/get_user_responses.go
@@ -36,7 +36,7 @@ func (o *GetUserReader) ReadResponse(response runtime.ClientResponse, consumer r
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/{id}] getUser", response, response.Code())
 	}
 }
 
@@ -45,7 +45,8 @@ func NewGetUserOK() *GetUserOK {
 	return &GetUserOK{}
 }
 
-/* GetUserOK describes a response with status code 200, with default header values.
+/*
+GetUserOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -53,9 +54,44 @@ type GetUserOK struct {
 	Payload *models.UserResponse
 }
 
+// IsSuccess returns true when this get user o k response has a 2xx status code
+func (o *GetUserOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get user o k response has a 3xx status code
+func (o *GetUserOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get user o k response has a 4xx status code
+func (o *GetUserOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get user o k response has a 5xx status code
+func (o *GetUserOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get user o k response a status code equal to that given
+func (o *GetUserOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get user o k response
+func (o *GetUserOK) Code() int {
+	return 200
+}
+
 func (o *GetUserOK) Error() string {
 	return fmt.Sprintf("[GET /users/{id}][%d] getUserOK  %+v", 200, o.Payload)
 }
+
+func (o *GetUserOK) String() string {
+	return fmt.Sprintf("[GET /users/{id}][%d] getUserOK  %+v", 200, o.Payload)
+}
+
 func (o *GetUserOK) GetPayload() *models.UserResponse {
 	return o.Payload
 }
@@ -77,7 +113,8 @@ func NewGetUserNotFound() *GetUserNotFound {
 	return &GetUserNotFound{}
 }
 
-/* GetUserNotFound describes a response with status code 404, with default header values.
+/*
+GetUserNotFound describes a response with status code 404, with default header values.
 
 Entity Not Found
 */
@@ -85,9 +122,44 @@ type GetUserNotFound struct {
 	Payload *models.NotFound
 }
 
+// IsSuccess returns true when this get user not found response has a 2xx status code
+func (o *GetUserNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get user not found response has a 3xx status code
+func (o *GetUserNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get user not found response has a 4xx status code
+func (o *GetUserNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get user not found response has a 5xx status code
+func (o *GetUserNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get user not found response a status code equal to that given
+func (o *GetUserNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the get user not found response
+func (o *GetUserNotFound) Code() int {
+	return 404
+}
+
 func (o *GetUserNotFound) Error() string {
 	return fmt.Sprintf("[GET /users/{id}][%d] getUserNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetUserNotFound) String() string {
+	return fmt.Sprintf("[GET /users/{id}][%d] getUserNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetUserNotFound) GetPayload() *models.NotFound {
 	return o.Payload
 }

--- a/client/users/get_users_parameters.go
+++ b/client/users/get_users_parameters.go
@@ -53,10 +53,12 @@ func NewGetUsersParamsWithHTTPClient(client *http.Client) *GetUsersParams {
 	}
 }
 
-/* GetUsersParams contains all the parameters to send to the API endpoint
-   for the get users operation.
+/*
+GetUsersParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get users operation.
+
+	Typically these are written to a http.Request.
 */
 type GetUsersParams struct {
 

--- a/client/users/get_users_responses.go
+++ b/client/users/get_users_responses.go
@@ -30,7 +30,7 @@ func (o *GetUsersReader) ReadResponse(response runtime.ClientResponse, consumer 
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users] getUsers", response, response.Code())
 	}
 }
 
@@ -39,7 +39,8 @@ func NewGetUsersOK() *GetUsersOK {
 	return &GetUsersOK{}
 }
 
-/* GetUsersOK describes a response with status code 200, with default header values.
+/*
+GetUsersOK describes a response with status code 200, with default header values.
 
 OK Response
 */
@@ -47,9 +48,44 @@ type GetUsersOK struct {
 	Payload *models.UsersResponse
 }
 
+// IsSuccess returns true when this get users o k response has a 2xx status code
+func (o *GetUsersOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get users o k response has a 3xx status code
+func (o *GetUsersOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get users o k response has a 4xx status code
+func (o *GetUsersOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get users o k response has a 5xx status code
+func (o *GetUsersOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get users o k response a status code equal to that given
+func (o *GetUsersOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the get users o k response
+func (o *GetUsersOK) Code() int {
+	return 200
+}
+
 func (o *GetUsersOK) Error() string {
 	return fmt.Sprintf("[GET /users][%d] getUsersOK  %+v", 200, o.Payload)
 }
+
+func (o *GetUsersOK) String() string {
+	return fmt.Sprintf("[GET /users][%d] getUsersOK  %+v", 200, o.Payload)
+}
+
 func (o *GetUsersOK) GetPayload() *models.UsersResponse {
 	return o.Payload
 }

--- a/client/users/users_client.go
+++ b/client/users/users_client.go
@@ -52,7 +52,7 @@ type ClientService interface {
 }
 
 /*
-  GetContactsForUser Returns the contact users for a student user
+GetContactsForUser Returns the contact users for a student user
 */
 func (a *Client) GetContactsForUser(params *GetContactsForUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetContactsForUserOK, error) {
 	// TODO: Validate the params before sending
@@ -91,7 +91,7 @@ func (a *Client) GetContactsForUser(params *GetContactsForUserParams, authInfo r
 }
 
 /*
-  GetDistrictForUser Returns the district for a user
+GetDistrictForUser Returns the district for a user
 */
 func (a *Client) GetDistrictForUser(params *GetDistrictForUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetDistrictForUserOK, error) {
 	// TODO: Validate the params before sending
@@ -130,7 +130,7 @@ func (a *Client) GetDistrictForUser(params *GetDistrictForUserParams, authInfo r
 }
 
 /*
-  GetResourcesForUser Returns the resources for a user
+GetResourcesForUser Returns the resources for a user
 */
 func (a *Client) GetResourcesForUser(params *GetResourcesForUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetResourcesForUserOK, error) {
 	// TODO: Validate the params before sending
@@ -169,7 +169,7 @@ func (a *Client) GetResourcesForUser(params *GetResourcesForUserParams, authInfo
 }
 
 /*
-  GetSchoolsForUser Returns the schools for a user
+GetSchoolsForUser Returns the schools for a user
 */
 func (a *Client) GetSchoolsForUser(params *GetSchoolsForUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSchoolsForUserOK, error) {
 	// TODO: Validate the params before sending
@@ -208,7 +208,7 @@ func (a *Client) GetSchoolsForUser(params *GetSchoolsForUserParams, authInfo run
 }
 
 /*
-  GetSectionsForUser Returns the sections for a user
+GetSectionsForUser Returns the sections for a user
 */
 func (a *Client) GetSectionsForUser(params *GetSectionsForUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSectionsForUserOK, error) {
 	// TODO: Validate the params before sending
@@ -247,7 +247,7 @@ func (a *Client) GetSectionsForUser(params *GetSectionsForUserParams, authInfo r
 }
 
 /*
-  GetStudentsForUser Returns the student users for a teacher or contact user
+GetStudentsForUser Returns the student users for a teacher or contact user
 */
 func (a *Client) GetStudentsForUser(params *GetStudentsForUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetStudentsForUserOK, error) {
 	// TODO: Validate the params before sending
@@ -286,7 +286,7 @@ func (a *Client) GetStudentsForUser(params *GetStudentsForUserParams, authInfo r
 }
 
 /*
-  GetTeachersForUser Returns the teacher users for a student user
+GetTeachersForUser Returns the teacher users for a student user
 */
 func (a *Client) GetTeachersForUser(params *GetTeachersForUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetTeachersForUserOK, error) {
 	// TODO: Validate the params before sending
@@ -325,7 +325,7 @@ func (a *Client) GetTeachersForUser(params *GetTeachersForUserParams, authInfo r
 }
 
 /*
-  GetUser Returns a specific user
+GetUser Returns a specific user
 */
 func (a *Client) GetUser(params *GetUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUserOK, error) {
 	// TODO: Validate the params before sending
@@ -364,7 +364,7 @@ func (a *Client) GetUser(params *GetUserParams, authInfo runtime.ClientAuthInfoW
 }
 
 /*
-  GetUsers Returns a list of contact, district admin, staff, student, and/or teacher users
+GetUsers Returns a list of contact, district admin, staff, student, and/or teacher users
 */
 func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersOK, error) {
 	// TODO: Validate the params before sending

--- a/models/contact.go
+++ b/models/contact.go
@@ -121,6 +121,8 @@ func (m *Contact) validateStudentRelationships(formats strfmt.Registry) error {
 			if err := m.StudentRelationships[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("student_relationships" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("student_relationships" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -150,9 +152,16 @@ func (m *Contact) contextValidateStudentRelationships(ctx context.Context, forma
 	for i := 0; i < len(m.StudentRelationships); i++ {
 
 		if m.StudentRelationships[i] != nil {
+
+			if swag.IsZero(m.StudentRelationships[i]) { // not required
+				return nil
+			}
+
 			if err := m.StudentRelationships[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("student_relationships" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("student_relationships" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/course_object.go
+++ b/models/course_object.go
@@ -45,6 +45,8 @@ func (m *CourseObject) validateObject(formats strfmt.Registry) error {
 		if err := m.Object.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *CourseObject) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *CourseObject) contextValidateObject(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Object != nil {
+
+		if swag.IsZero(m.Object) { // not required
+			return nil
+		}
+
 		if err := m.Object.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}

--- a/models/course_response.go
+++ b/models/course_response.go
@@ -45,6 +45,8 @@ func (m *CourseResponse) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *CourseResponse) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *CourseResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/courses_created.go
+++ b/models/courses_created.go
@@ -184,6 +184,8 @@ func (m *CoursesCreated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *CoursesCreated) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *CoursesCreated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/courses_deleted.go
+++ b/models/courses_deleted.go
@@ -184,6 +184,8 @@ func (m *CoursesDeleted) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *CoursesDeleted) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *CoursesDeleted) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/courses_response.go
+++ b/models/courses_response.go
@@ -58,6 +58,8 @@ func (m *CoursesResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *CoursesResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *CoursesResponse) contextValidateData(ctx context.Context, formats strfm
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *CoursesResponse) contextValidateLinks(ctx context.Context, formats strf
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/courses_updated.go
+++ b/models/courses_updated.go
@@ -196,6 +196,8 @@ func (m *CoursesUpdated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -221,9 +223,16 @@ func (m *CoursesUpdated) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *CoursesUpdated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/district.go
+++ b/models/district.go
@@ -111,6 +111,8 @@ func (m *District) validateDistrictContact(formats strfmt.Registry) error {
 		if err := m.DistrictContact.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("district_contact")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("district_contact")
 			}
 			return err
 		}
@@ -238,9 +240,16 @@ func (m *District) ContextValidate(ctx context.Context, formats strfmt.Registry)
 func (m *District) contextValidateDistrictContact(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.DistrictContact != nil {
+
+		if swag.IsZero(m.DistrictContact) { // not required
+			return nil
+		}
+
 		if err := m.DistrictContact.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("district_contact")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("district_contact")
 			}
 			return err
 		}

--- a/models/district_contact.go
+++ b/models/district_contact.go
@@ -57,6 +57,8 @@ func (m *DistrictContact) validateName(formats strfmt.Registry) error {
 		if err := m.Name.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("name")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("name")
 			}
 			return err
 		}
@@ -82,9 +84,16 @@ func (m *DistrictContact) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *DistrictContact) contextValidateName(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Name != nil {
+
+		if swag.IsZero(m.Name) { // not required
+			return nil
+		}
+
 		if err := m.Name.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("name")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("name")
 			}
 			return err
 		}

--- a/models/district_object.go
+++ b/models/district_object.go
@@ -45,6 +45,8 @@ func (m *DistrictObject) validateObject(formats strfmt.Registry) error {
 		if err := m.Object.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *DistrictObject) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *DistrictObject) contextValidateObject(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Object != nil {
+
+		if swag.IsZero(m.Object) { // not required
+			return nil
+		}
+
 		if err := m.Object.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}

--- a/models/district_response.go
+++ b/models/district_response.go
@@ -45,6 +45,8 @@ func (m *DistrictResponse) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *DistrictResponse) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *DistrictResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/districts_created.go
+++ b/models/districts_created.go
@@ -184,6 +184,8 @@ func (m *DistrictsCreated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *DistrictsCreated) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *DistrictsCreated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/districts_deleted.go
+++ b/models/districts_deleted.go
@@ -184,6 +184,8 @@ func (m *DistrictsDeleted) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *DistrictsDeleted) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *DistrictsDeleted) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/districts_response.go
+++ b/models/districts_response.go
@@ -58,6 +58,8 @@ func (m *DistrictsResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *DistrictsResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *DistrictsResponse) contextValidateData(ctx context.Context, formats str
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *DistrictsResponse) contextValidateLinks(ctx context.Context, formats st
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/districts_updated.go
+++ b/models/districts_updated.go
@@ -196,6 +196,8 @@ func (m *DistrictsUpdated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -221,9 +223,16 @@ func (m *DistrictsUpdated) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *DistrictsUpdated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/event.go
+++ b/models/event.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
@@ -102,7 +101,7 @@ func UnmarshalEventSlice(reader io.Reader, consumer runtime.Consumer) ([]Event, 
 // UnmarshalEvent unmarshals polymorphic Event
 func UnmarshalEvent(reader io.Reader, consumer runtime.Consumer) (Event, error) {
 	// we need to read this twice, so first into a buffer
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/models/event_response.go
+++ b/models/event_response.go
@@ -110,6 +110,8 @@ func (m *EventResponse) validateData(formats strfmt.Registry) error {
 	if err := m.Data().Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("data")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("data")
 		}
 		return err
 	}
@@ -133,9 +135,15 @@ func (m *EventResponse) ContextValidate(ctx context.Context, formats strfmt.Regi
 
 func (m *EventResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Data()) { // not required
+		return nil
+	}
+
 	if err := m.Data().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("data")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("data")
 		}
 		return err
 	}

--- a/models/events_response.go
+++ b/models/events_response.go
@@ -58,6 +58,8 @@ func (m *EventsResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *EventsResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *EventsResponse) contextValidateData(ctx context.Context, formats strfmt
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *EventsResponse) contextValidateLinks(ctx context.Context, formats strfm
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/resource_object.go
+++ b/models/resource_object.go
@@ -45,6 +45,8 @@ func (m *ResourceObject) validateObject(formats strfmt.Registry) error {
 		if err := m.Object.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *ResourceObject) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *ResourceObject) contextValidateObject(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Object != nil {
+
+		if swag.IsZero(m.Object) { // not required
+			return nil
+		}
+
 		if err := m.Object.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}

--- a/models/resource_response.go
+++ b/models/resource_response.go
@@ -45,6 +45,8 @@ func (m *ResourceResponse) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *ResourceResponse) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *ResourceResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/resources_created.go
+++ b/models/resources_created.go
@@ -184,6 +184,8 @@ func (m *ResourcesCreated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *ResourcesCreated) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *ResourcesCreated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/resources_deleted.go
+++ b/models/resources_deleted.go
@@ -184,6 +184,8 @@ func (m *ResourcesDeleted) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *ResourcesDeleted) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *ResourcesDeleted) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/resources_response.go
+++ b/models/resources_response.go
@@ -58,6 +58,8 @@ func (m *ResourcesResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *ResourcesResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *ResourcesResponse) contextValidateData(ctx context.Context, formats str
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *ResourcesResponse) contextValidateLinks(ctx context.Context, formats st
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/resources_updated.go
+++ b/models/resources_updated.go
@@ -196,6 +196,8 @@ func (m *ResourcesUpdated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -221,9 +223,16 @@ func (m *ResourcesUpdated) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *ResourcesUpdated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/roles.go
+++ b/models/roles.go
@@ -73,6 +73,8 @@ func (m *Roles) validateContact(formats strfmt.Registry) error {
 		if err := m.Contact.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("contact")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("contact")
 			}
 			return err
 		}
@@ -90,6 +92,8 @@ func (m *Roles) validateDistrictadmin(formats strfmt.Registry) error {
 		if err := m.Districtadmin.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("districtadmin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("districtadmin")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *Roles) validateStaff(formats strfmt.Registry) error {
 		if err := m.Staff.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("staff")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("staff")
 			}
 			return err
 		}
@@ -124,6 +130,8 @@ func (m *Roles) validateStudent(formats strfmt.Registry) error {
 		if err := m.Student.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("student")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("student")
 			}
 			return err
 		}
@@ -141,6 +149,8 @@ func (m *Roles) validateTeacher(formats strfmt.Registry) error {
 		if err := m.Teacher.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("teacher")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("teacher")
 			}
 			return err
 		}
@@ -182,9 +192,16 @@ func (m *Roles) ContextValidate(ctx context.Context, formats strfmt.Registry) er
 func (m *Roles) contextValidateContact(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Contact != nil {
+
+		if swag.IsZero(m.Contact) { // not required
+			return nil
+		}
+
 		if err := m.Contact.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("contact")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("contact")
 			}
 			return err
 		}
@@ -196,9 +213,16 @@ func (m *Roles) contextValidateContact(ctx context.Context, formats strfmt.Regis
 func (m *Roles) contextValidateDistrictadmin(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Districtadmin != nil {
+
+		if swag.IsZero(m.Districtadmin) { // not required
+			return nil
+		}
+
 		if err := m.Districtadmin.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("districtadmin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("districtadmin")
 			}
 			return err
 		}
@@ -210,9 +234,16 @@ func (m *Roles) contextValidateDistrictadmin(ctx context.Context, formats strfmt
 func (m *Roles) contextValidateStaff(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Staff != nil {
+
+		if swag.IsZero(m.Staff) { // not required
+			return nil
+		}
+
 		if err := m.Staff.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("staff")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("staff")
 			}
 			return err
 		}
@@ -224,9 +255,16 @@ func (m *Roles) contextValidateStaff(ctx context.Context, formats strfmt.Registr
 func (m *Roles) contextValidateStudent(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Student != nil {
+
+		if swag.IsZero(m.Student) { // not required
+			return nil
+		}
+
 		if err := m.Student.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("student")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("student")
 			}
 			return err
 		}
@@ -238,9 +276,16 @@ func (m *Roles) contextValidateStudent(ctx context.Context, formats strfmt.Regis
 func (m *Roles) contextValidateTeacher(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Teacher != nil {
+
+		if swag.IsZero(m.Teacher) { // not required
+			return nil
+		}
+
 		if err := m.Teacher.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("teacher")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("teacher")
 			}
 			return err
 		}

--- a/models/school.go
+++ b/models/school.go
@@ -242,6 +242,8 @@ func (m *School) validateLocation(formats strfmt.Registry) error {
 		if err := m.Location.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("location")
 			}
 			return err
 		}
@@ -361,6 +363,8 @@ func (m *School) validatePrincipal(formats strfmt.Registry) error {
 		if err := m.Principal.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("principal")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("principal")
 			}
 			return err
 		}
@@ -390,9 +394,16 @@ func (m *School) ContextValidate(ctx context.Context, formats strfmt.Registry) e
 func (m *School) contextValidateLocation(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Location != nil {
+
+		if swag.IsZero(m.Location) { // not required
+			return nil
+		}
+
 		if err := m.Location.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("location")
 			}
 			return err
 		}
@@ -404,9 +415,16 @@ func (m *School) contextValidateLocation(ctx context.Context, formats strfmt.Reg
 func (m *School) contextValidatePrincipal(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Principal != nil {
+
+		if swag.IsZero(m.Principal) { // not required
+			return nil
+		}
+
 		if err := m.Principal.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("principal")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("principal")
 			}
 			return err
 		}

--- a/models/school_object.go
+++ b/models/school_object.go
@@ -45,6 +45,8 @@ func (m *SchoolObject) validateObject(formats strfmt.Registry) error {
 		if err := m.Object.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *SchoolObject) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *SchoolObject) contextValidateObject(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Object != nil {
+
+		if swag.IsZero(m.Object) { // not required
+			return nil
+		}
+
 		if err := m.Object.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}

--- a/models/school_response.go
+++ b/models/school_response.go
@@ -45,6 +45,8 @@ func (m *SchoolResponse) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *SchoolResponse) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *SchoolResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/schools_created.go
+++ b/models/schools_created.go
@@ -184,6 +184,8 @@ func (m *SchoolsCreated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *SchoolsCreated) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *SchoolsCreated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/schools_deleted.go
+++ b/models/schools_deleted.go
@@ -184,6 +184,8 @@ func (m *SchoolsDeleted) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *SchoolsDeleted) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *SchoolsDeleted) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/schools_response.go
+++ b/models/schools_response.go
@@ -58,6 +58,8 @@ func (m *SchoolsResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *SchoolsResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *SchoolsResponse) contextValidateData(ctx context.Context, formats strfm
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *SchoolsResponse) contextValidateLinks(ctx context.Context, formats strf
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/schools_updated.go
+++ b/models/schools_updated.go
@@ -196,6 +196,8 @@ func (m *SchoolsUpdated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -221,9 +223,16 @@ func (m *SchoolsUpdated) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *SchoolsUpdated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/section.go
+++ b/models/section.go
@@ -23,6 +23,9 @@ type Section struct {
 	// course
 	Course *string `json:"course,omitempty"`
 
+	// course name
+	CourseName *string `json:"course_name,omitempty"`
+
 	// created
 	// Format: datetime
 	Created strfmt.DateTime `json:"created,omitempty"`
@@ -74,6 +77,9 @@ type Section struct {
 
 	// term id
 	TermID *string `json:"term_id,omitempty"`
+
+	// term name
+	TermName *string `json:"term_name,omitempty"`
 }
 
 // Validate validates this section

--- a/models/section_object.go
+++ b/models/section_object.go
@@ -45,6 +45,8 @@ func (m *SectionObject) validateObject(formats strfmt.Registry) error {
 		if err := m.Object.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *SectionObject) ContextValidate(ctx context.Context, formats strfmt.Regi
 func (m *SectionObject) contextValidateObject(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Object != nil {
+
+		if swag.IsZero(m.Object) { // not required
+			return nil
+		}
+
 		if err := m.Object.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}

--- a/models/section_response.go
+++ b/models/section_response.go
@@ -45,6 +45,8 @@ func (m *SectionResponse) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *SectionResponse) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *SectionResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/sections_created.go
+++ b/models/sections_created.go
@@ -184,6 +184,8 @@ func (m *SectionsCreated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *SectionsCreated) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *SectionsCreated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/sections_deleted.go
+++ b/models/sections_deleted.go
@@ -184,6 +184,8 @@ func (m *SectionsDeleted) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *SectionsDeleted) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *SectionsDeleted) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/sections_response.go
+++ b/models/sections_response.go
@@ -58,6 +58,8 @@ func (m *SectionsResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *SectionsResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *SectionsResponse) contextValidateData(ctx context.Context, formats strf
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *SectionsResponse) contextValidateLinks(ctx context.Context, formats str
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/sections_updated.go
+++ b/models/sections_updated.go
@@ -196,6 +196,8 @@ func (m *SectionsUpdated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -221,9 +223,16 @@ func (m *SectionsUpdated) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *SectionsUpdated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/staff.go
+++ b/models/staff.go
@@ -66,6 +66,8 @@ func (m *Staff) validateCredentials(formats strfmt.Registry) error {
 		if err := m.Credentials.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}
@@ -91,9 +93,16 @@ func (m *Staff) ContextValidate(ctx context.Context, formats strfmt.Registry) er
 func (m *Staff) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
+		if swag.IsZero(m.Credentials) { // not required
+			return nil
+		}
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}

--- a/models/student.go
+++ b/models/student.go
@@ -179,6 +179,8 @@ func (m *Student) validateCredentials(formats strfmt.Registry) error {
 		if err := m.Credentials.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}
@@ -258,6 +260,8 @@ func (m *Student) validateEnrollments(formats strfmt.Registry) error {
 			if err := m.Enrollments[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("enrollments" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("enrollments" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -664,6 +668,8 @@ func (m *Student) validateLocation(formats strfmt.Registry) error {
 		if err := m.Location.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("location")
 			}
 			return err
 		}
@@ -757,9 +763,16 @@ func (m *Student) ContextValidate(ctx context.Context, formats strfmt.Registry) 
 func (m *Student) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
+		if swag.IsZero(m.Credentials) { // not required
+			return nil
+		}
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}
@@ -773,9 +786,16 @@ func (m *Student) contextValidateEnrollments(ctx context.Context, formats strfmt
 	for i := 0; i < len(m.Enrollments); i++ {
 
 		if m.Enrollments[i] != nil {
+
+			if swag.IsZero(m.Enrollments[i]) { // not required
+				return nil
+			}
+
 			if err := m.Enrollments[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("enrollments" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("enrollments" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -789,9 +809,16 @@ func (m *Student) contextValidateEnrollments(ctx context.Context, formats strfmt
 func (m *Student) contextValidateLocation(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Location != nil {
+
+		if swag.IsZero(m.Location) { // not required
+			return nil
+		}
+
 		if err := m.Location.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("location")
 			}
 			return err
 		}

--- a/models/teacher.go
+++ b/models/teacher.go
@@ -108,6 +108,8 @@ func (m *Teacher) validateCredentials(formats strfmt.Registry) error {
 		if err := m.Credentials.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}
@@ -137,6 +139,8 @@ func (m *Teacher) validateName(formats strfmt.Registry) error {
 		if err := m.Name.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("name")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("name")
 			}
 			return err
 		}
@@ -166,9 +170,16 @@ func (m *Teacher) ContextValidate(ctx context.Context, formats strfmt.Registry) 
 func (m *Teacher) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
+		if swag.IsZero(m.Credentials) { // not required
+			return nil
+		}
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}
@@ -180,9 +191,16 @@ func (m *Teacher) contextValidateCredentials(ctx context.Context, formats strfmt
 func (m *Teacher) contextValidateName(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Name != nil {
+
+		if swag.IsZero(m.Name) { // not required
+			return nil
+		}
+
 		if err := m.Name.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("name")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("name")
 			}
 			return err
 		}

--- a/models/term_object.go
+++ b/models/term_object.go
@@ -45,6 +45,8 @@ func (m *TermObject) validateObject(formats strfmt.Registry) error {
 		if err := m.Object.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *TermObject) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *TermObject) contextValidateObject(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Object != nil {
+
+		if swag.IsZero(m.Object) { // not required
+			return nil
+		}
+
 		if err := m.Object.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}

--- a/models/term_response.go
+++ b/models/term_response.go
@@ -45,6 +45,8 @@ func (m *TermResponse) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *TermResponse) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *TermResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/terms_created.go
+++ b/models/terms_created.go
@@ -184,6 +184,8 @@ func (m *TermsCreated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *TermsCreated) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *TermsCreated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/terms_deleted.go
+++ b/models/terms_deleted.go
@@ -184,6 +184,8 @@ func (m *TermsDeleted) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *TermsDeleted) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *TermsDeleted) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/terms_response.go
+++ b/models/terms_response.go
@@ -58,6 +58,8 @@ func (m *TermsResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *TermsResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *TermsResponse) contextValidateData(ctx context.Context, formats strfmt.
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *TermsResponse) contextValidateLinks(ctx context.Context, formats strfmt
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/terms_updated.go
+++ b/models/terms_updated.go
@@ -196,6 +196,8 @@ func (m *TermsUpdated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -221,9 +223,16 @@ func (m *TermsUpdated) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *TermsUpdated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/user.go
+++ b/models/user.go
@@ -102,6 +102,8 @@ func (m *User) validateName(formats strfmt.Registry) error {
 		if err := m.Name.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("name")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("name")
 			}
 			return err
 		}
@@ -119,6 +121,8 @@ func (m *User) validateRoles(formats strfmt.Registry) error {
 		if err := m.Roles.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("roles")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("roles")
 			}
 			return err
 		}
@@ -148,9 +152,16 @@ func (m *User) ContextValidate(ctx context.Context, formats strfmt.Registry) err
 func (m *User) contextValidateName(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Name != nil {
+
+		if swag.IsZero(m.Name) { // not required
+			return nil
+		}
+
 		if err := m.Name.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("name")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("name")
 			}
 			return err
 		}
@@ -162,9 +173,16 @@ func (m *User) contextValidateName(ctx context.Context, formats strfmt.Registry)
 func (m *User) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Roles != nil {
+
+		if swag.IsZero(m.Roles) { // not required
+			return nil
+		}
+
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("roles")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("roles")
 			}
 			return err
 		}

--- a/models/user_object.go
+++ b/models/user_object.go
@@ -45,6 +45,8 @@ func (m *UserObject) validateObject(formats strfmt.Registry) error {
 		if err := m.Object.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *UserObject) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *UserObject) contextValidateObject(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Object != nil {
+
+		if swag.IsZero(m.Object) { // not required
+			return nil
+		}
+
 		if err := m.Object.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("object")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("object")
 			}
 			return err
 		}

--- a/models/user_response.go
+++ b/models/user_response.go
@@ -45,6 +45,8 @@ func (m *UserResponse) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -70,9 +72,16 @@ func (m *UserResponse) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *UserResponse) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/users_created.go
+++ b/models/users_created.go
@@ -184,6 +184,8 @@ func (m *UsersCreated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *UsersCreated) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *UsersCreated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/users_deleted.go
+++ b/models/users_deleted.go
@@ -184,6 +184,8 @@ func (m *UsersDeleted) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -209,9 +211,16 @@ func (m *UsersDeleted) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *UsersDeleted) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/models/users_response.go
+++ b/models/users_response.go
@@ -58,6 +58,8 @@ func (m *UsersResponse) validateData(formats strfmt.Registry) error {
 			if err := m.Data[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -82,6 +84,8 @@ func (m *UsersResponse) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -115,9 +119,16 @@ func (m *UsersResponse) contextValidateData(ctx context.Context, formats strfmt.
 	for i := 0; i < len(m.Data); i++ {
 
 		if m.Data[i] != nil {
+
+			if swag.IsZero(m.Data[i]) { // not required
+				return nil
+			}
+
 			if err := m.Data[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("data" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("data" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -133,9 +144,16 @@ func (m *UsersResponse) contextValidateLinks(ctx context.Context, formats strfmt
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
+
+			if swag.IsZero(m.Links[i]) { // not required
+				return nil
+			}
+
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("links" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/models/users_updated.go
+++ b/models/users_updated.go
@@ -196,6 +196,8 @@ func (m *UsersUpdated) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}
@@ -221,9 +223,16 @@ func (m *UsersUpdated) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *UsersUpdated) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("data")
 			}
 			return err
 		}

--- a/restapi/doc.go
+++ b/restapi/doc.go
@@ -2,18 +2,18 @@
 
 // Package restapi Data API
 //
-//  Serves the Clever Data API
-//  Schemes:
-//    https
-//  Host: api.clever.com
-//  BasePath: /
-//  Version: 3.0.0
+//	Serves the Clever Data API
+//	Schemes:
+//	  https
+//	Host: api.clever.com
+//	BasePath: /
+//	Version: 3.0.0
 //
-//  Consumes:
-//    - application/json
+//	Consumes:
+//	  - application/json
 //
-//  Produces:
-//    - application/json
+//	Produces:
+//	  - application/json
 //
 // swagger:meta
 package restapi

--- a/restapi/doc.go
+++ b/restapi/doc.go
@@ -7,7 +7,7 @@
 //	  https
 //	Host: api.clever.com
 //	BasePath: /
-//	Version: 3.0.0
+//	Version: 3.0.1
 //
 //	Consumes:
 //	  - application/json

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -28,7 +28,7 @@ func init() {
   "info": {
     "description": "Serves the Clever Data API",
     "title": "Data API",
-    "version": "3.0.0"
+    "version": "3.0.1"
   },
   "host": "api.clever.com",
   "paths": {
@@ -2392,6 +2392,10 @@ func init() {
           "x-nullable": true,
           "x-validation": true
         },
+        "course_name": {
+          "type": "string",
+          "x-nullable": true
+        },
         "created": {
           "type": "string",
           "format": "datetime",
@@ -2502,6 +2506,10 @@ func init() {
           "type": "string",
           "x-nullable": true,
           "x-validation": true
+        },
+        "term_name": {
+          "type": "string",
+          "x-nullable": true
         }
       }
     },
@@ -3418,7 +3426,7 @@ func init() {
   "info": {
     "description": "Serves the Clever Data API",
     "title": "Data API",
-    "version": "3.0.0"
+    "version": "3.0.1"
   },
   "host": "api.clever.com",
   "paths": {
@@ -5893,6 +5901,10 @@ func init() {
           "x-nullable": true,
           "x-validation": true
         },
+        "course_name": {
+          "type": "string",
+          "x-nullable": true
+        },
         "created": {
           "type": "string",
           "format": "datetime",
@@ -6003,6 +6015,10 @@ func init() {
           "type": "string",
           "x-nullable": true,
           "x-validation": true
+        },
+        "term_name": {
+          "type": "string",
+          "x-nullable": true
         }
       }
     },

--- a/restapi/operations/clever_api.go
+++ b/restapi/operations/clever_api.go
@@ -846,6 +846,6 @@ func (o *CleverAPI) AddMiddlewareFor(method, path string, builder middleware.Bui
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }

--- a/restapi/operations/courses/get_course.go
+++ b/restapi/operations/courses/get_course.go
@@ -29,10 +29,10 @@ func NewGetCourse(ctx *middleware.Context, handler GetCourseHandler) *GetCourse 
 	return &GetCourse{Context: ctx, Handler: handler}
 }
 
-/* GetCourse swagger:route GET /courses/{id} Courses getCourse
+/*
+	GetCourse swagger:route GET /courses/{id} Courses getCourse
 
 Returns a specific course
-
 */
 type GetCourse struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetCourse struct {
 func (o *GetCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetCourseParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/courses/get_course_responses.go
+++ b/restapi/operations/courses/get_course_responses.go
@@ -16,7 +16,8 @@ import (
 // GetCourseOKCode is the HTTP code returned for type GetCourseOK
 const GetCourseOKCode int = 200
 
-/*GetCourseOK OK Response
+/*
+GetCourseOK OK Response
 
 swagger:response getCourseOK
 */
@@ -60,7 +61,8 @@ func (o *GetCourseOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // GetCourseNotFoundCode is the HTTP code returned for type GetCourseNotFound
 const GetCourseNotFoundCode int = 404
 
-/*GetCourseNotFound Entity Not Found
+/*
+GetCourseNotFound Entity Not Found
 
 swagger:response getCourseNotFound
 */

--- a/restapi/operations/courses/get_courses.go
+++ b/restapi/operations/courses/get_courses.go
@@ -29,10 +29,10 @@ func NewGetCourses(ctx *middleware.Context, handler GetCoursesHandler) *GetCours
 	return &GetCourses{Context: ctx, Handler: handler}
 }
 
-/* GetCourses swagger:route GET /courses Courses getCourses
+/*
+	GetCourses swagger:route GET /courses Courses getCourses
 
 Returns a list of courses
-
 */
 type GetCourses struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetCourses struct {
 func (o *GetCourses) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetCoursesParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetCourses) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/courses/get_courses_responses.go
+++ b/restapi/operations/courses/get_courses_responses.go
@@ -16,7 +16,8 @@ import (
 // GetCoursesOKCode is the HTTP code returned for type GetCoursesOK
 const GetCoursesOKCode int = 200
 
-/*GetCoursesOK OK Response
+/*
+GetCoursesOK OK Response
 
 swagger:response getCoursesOK
 */

--- a/restapi/operations/courses/get_district_for_course.go
+++ b/restapi/operations/courses/get_district_for_course.go
@@ -29,10 +29,10 @@ func NewGetDistrictForCourse(ctx *middleware.Context, handler GetDistrictForCour
 	return &GetDistrictForCourse{Context: ctx, Handler: handler}
 }
 
-/* GetDistrictForCourse swagger:route GET /courses/{id}/district Courses getDistrictForCourse
+/*
+	GetDistrictForCourse swagger:route GET /courses/{id}/district Courses getDistrictForCourse
 
 Returns the district for a course
-
 */
 type GetDistrictForCourse struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetDistrictForCourse struct {
 func (o *GetDistrictForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetDistrictForCourseParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetDistrictForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/courses/get_district_for_course_responses.go
+++ b/restapi/operations/courses/get_district_for_course_responses.go
@@ -16,7 +16,8 @@ import (
 // GetDistrictForCourseOKCode is the HTTP code returned for type GetDistrictForCourseOK
 const GetDistrictForCourseOKCode int = 200
 
-/*GetDistrictForCourseOK OK Response
+/*
+GetDistrictForCourseOK OK Response
 
 swagger:response getDistrictForCourseOK
 */
@@ -60,7 +61,8 @@ func (o *GetDistrictForCourseOK) WriteResponse(rw http.ResponseWriter, producer 
 // GetDistrictForCourseNotFoundCode is the HTTP code returned for type GetDistrictForCourseNotFound
 const GetDistrictForCourseNotFoundCode int = 404
 
-/*GetDistrictForCourseNotFound Entity Not Found
+/*
+GetDistrictForCourseNotFound Entity Not Found
 
 swagger:response getDistrictForCourseNotFound
 */

--- a/restapi/operations/courses/get_resources_for_course.go
+++ b/restapi/operations/courses/get_resources_for_course.go
@@ -29,10 +29,10 @@ func NewGetResourcesForCourse(ctx *middleware.Context, handler GetResourcesForCo
 	return &GetResourcesForCourse{Context: ctx, Handler: handler}
 }
 
-/* GetResourcesForCourse swagger:route GET /courses/{id}/resources Courses getResourcesForCourse
+/*
+	GetResourcesForCourse swagger:route GET /courses/{id}/resources Courses getResourcesForCourse
 
 Returns the resources for a course
-
 */
 type GetResourcesForCourse struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetResourcesForCourse struct {
 func (o *GetResourcesForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetResourcesForCourseParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetResourcesForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/courses/get_resources_for_course_responses.go
+++ b/restapi/operations/courses/get_resources_for_course_responses.go
@@ -16,7 +16,8 @@ import (
 // GetResourcesForCourseOKCode is the HTTP code returned for type GetResourcesForCourseOK
 const GetResourcesForCourseOKCode int = 200
 
-/*GetResourcesForCourseOK OK Response
+/*
+GetResourcesForCourseOK OK Response
 
 swagger:response getResourcesForCourseOK
 */
@@ -60,7 +61,8 @@ func (o *GetResourcesForCourseOK) WriteResponse(rw http.ResponseWriter, producer
 // GetResourcesForCourseNotFoundCode is the HTTP code returned for type GetResourcesForCourseNotFound
 const GetResourcesForCourseNotFoundCode int = 404
 
-/*GetResourcesForCourseNotFound Entity Not Found
+/*
+GetResourcesForCourseNotFound Entity Not Found
 
 swagger:response getResourcesForCourseNotFound
 */

--- a/restapi/operations/courses/get_schools_for_course.go
+++ b/restapi/operations/courses/get_schools_for_course.go
@@ -29,10 +29,10 @@ func NewGetSchoolsForCourse(ctx *middleware.Context, handler GetSchoolsForCourse
 	return &GetSchoolsForCourse{Context: ctx, Handler: handler}
 }
 
-/* GetSchoolsForCourse swagger:route GET /courses/{id}/schools Courses getSchoolsForCourse
+/*
+	GetSchoolsForCourse swagger:route GET /courses/{id}/schools Courses getSchoolsForCourse
 
 Returns the schools for a course
-
 */
 type GetSchoolsForCourse struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSchoolsForCourse struct {
 func (o *GetSchoolsForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSchoolsForCourseParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSchoolsForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/courses/get_schools_for_course_responses.go
+++ b/restapi/operations/courses/get_schools_for_course_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSchoolsForCourseOKCode is the HTTP code returned for type GetSchoolsForCourseOK
 const GetSchoolsForCourseOKCode int = 200
 
-/*GetSchoolsForCourseOK OK Response
+/*
+GetSchoolsForCourseOK OK Response
 
 swagger:response getSchoolsForCourseOK
 */
@@ -60,7 +61,8 @@ func (o *GetSchoolsForCourseOK) WriteResponse(rw http.ResponseWriter, producer r
 // GetSchoolsForCourseNotFoundCode is the HTTP code returned for type GetSchoolsForCourseNotFound
 const GetSchoolsForCourseNotFoundCode int = 404
 
-/*GetSchoolsForCourseNotFound Entity Not Found
+/*
+GetSchoolsForCourseNotFound Entity Not Found
 
 swagger:response getSchoolsForCourseNotFound
 */

--- a/restapi/operations/courses/get_sections_for_course.go
+++ b/restapi/operations/courses/get_sections_for_course.go
@@ -29,10 +29,10 @@ func NewGetSectionsForCourse(ctx *middleware.Context, handler GetSectionsForCour
 	return &GetSectionsForCourse{Context: ctx, Handler: handler}
 }
 
-/* GetSectionsForCourse swagger:route GET /courses/{id}/sections Courses getSectionsForCourse
+/*
+	GetSectionsForCourse swagger:route GET /courses/{id}/sections Courses getSectionsForCourse
 
 Returns the sections for a course
-
 */
 type GetSectionsForCourse struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSectionsForCourse struct {
 func (o *GetSectionsForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSectionsForCourseParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSectionsForCourse) ServeHTTP(rw http.ResponseWriter, r *http.Request
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/courses/get_sections_for_course_responses.go
+++ b/restapi/operations/courses/get_sections_for_course_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSectionsForCourseOKCode is the HTTP code returned for type GetSectionsForCourseOK
 const GetSectionsForCourseOKCode int = 200
 
-/*GetSectionsForCourseOK OK Response
+/*
+GetSectionsForCourseOK OK Response
 
 swagger:response getSectionsForCourseOK
 */
@@ -60,7 +61,8 @@ func (o *GetSectionsForCourseOK) WriteResponse(rw http.ResponseWriter, producer 
 // GetSectionsForCourseNotFoundCode is the HTTP code returned for type GetSectionsForCourseNotFound
 const GetSectionsForCourseNotFoundCode int = 404
 
-/*GetSectionsForCourseNotFound Entity Not Found
+/*
+GetSectionsForCourseNotFound Entity Not Found
 
 swagger:response getSectionsForCourseNotFound
 */

--- a/restapi/operations/districts/get_district.go
+++ b/restapi/operations/districts/get_district.go
@@ -29,10 +29,10 @@ func NewGetDistrict(ctx *middleware.Context, handler GetDistrictHandler) *GetDis
 	return &GetDistrict{Context: ctx, Handler: handler}
 }
 
-/* GetDistrict swagger:route GET /districts/{id} Districts getDistrict
+/*
+	GetDistrict swagger:route GET /districts/{id} Districts getDistrict
 
 Returns a specific district
-
 */
 type GetDistrict struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetDistrict struct {
 func (o *GetDistrict) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetDistrictParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetDistrict) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/districts/get_district_responses.go
+++ b/restapi/operations/districts/get_district_responses.go
@@ -16,7 +16,8 @@ import (
 // GetDistrictOKCode is the HTTP code returned for type GetDistrictOK
 const GetDistrictOKCode int = 200
 
-/*GetDistrictOK OK Response
+/*
+GetDistrictOK OK Response
 
 swagger:response getDistrictOK
 */
@@ -60,7 +61,8 @@ func (o *GetDistrictOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // GetDistrictNotFoundCode is the HTTP code returned for type GetDistrictNotFound
 const GetDistrictNotFoundCode int = 404
 
-/*GetDistrictNotFound Entity Not Found
+/*
+GetDistrictNotFound Entity Not Found
 
 swagger:response getDistrictNotFound
 */

--- a/restapi/operations/districts/get_districts.go
+++ b/restapi/operations/districts/get_districts.go
@@ -29,10 +29,10 @@ func NewGetDistricts(ctx *middleware.Context, handler GetDistrictsHandler) *GetD
 	return &GetDistricts{Context: ctx, Handler: handler}
 }
 
-/* GetDistricts swagger:route GET /districts Districts getDistricts
+/*
+	GetDistricts swagger:route GET /districts Districts getDistricts
 
 Returns a list of districts
-
 */
 type GetDistricts struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetDistricts struct {
 func (o *GetDistricts) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetDistrictsParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetDistricts) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/districts/get_districts_responses.go
+++ b/restapi/operations/districts/get_districts_responses.go
@@ -16,7 +16,8 @@ import (
 // GetDistrictsOKCode is the HTTP code returned for type GetDistrictsOK
 const GetDistrictsOKCode int = 200
 
-/*GetDistrictsOK OK Response
+/*
+GetDistrictsOK OK Response
 
 swagger:response getDistrictsOK
 */

--- a/restapi/operations/events/get_event.go
+++ b/restapi/operations/events/get_event.go
@@ -29,10 +29,10 @@ func NewGetEvent(ctx *middleware.Context, handler GetEventHandler) *GetEvent {
 	return &GetEvent{Context: ctx, Handler: handler}
 }
 
-/* GetEvent swagger:route GET /events/{id} Events getEvent
+/*
+	GetEvent swagger:route GET /events/{id} Events getEvent
 
 Returns the specific event
-
 */
 type GetEvent struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetEvent struct {
 func (o *GetEvent) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetEventParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetEvent) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/events/get_event_responses.go
+++ b/restapi/operations/events/get_event_responses.go
@@ -16,7 +16,8 @@ import (
 // GetEventOKCode is the HTTP code returned for type GetEventOK
 const GetEventOKCode int = 200
 
-/*GetEventOK OK Response
+/*
+GetEventOK OK Response
 
 swagger:response getEventOK
 */
@@ -60,7 +61,8 @@ func (o *GetEventOK) WriteResponse(rw http.ResponseWriter, producer runtime.Prod
 // GetEventNotFoundCode is the HTTP code returned for type GetEventNotFound
 const GetEventNotFoundCode int = 404
 
-/*GetEventNotFound Entity Not Found
+/*
+GetEventNotFound Entity Not Found
 
 swagger:response getEventNotFound
 */

--- a/restapi/operations/events/get_events.go
+++ b/restapi/operations/events/get_events.go
@@ -29,10 +29,10 @@ func NewGetEvents(ctx *middleware.Context, handler GetEventsHandler) *GetEvents 
 	return &GetEvents{Context: ctx, Handler: handler}
 }
 
-/* GetEvents swagger:route GET /events Events getEvents
+/*
+	GetEvents swagger:route GET /events Events getEvents
 
 Returns a list of events
-
 */
 type GetEvents struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetEvents struct {
 func (o *GetEvents) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetEventsParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetEvents) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/events/get_events_responses.go
+++ b/restapi/operations/events/get_events_responses.go
@@ -16,7 +16,8 @@ import (
 // GetEventsOKCode is the HTTP code returned for type GetEventsOK
 const GetEventsOKCode int = 200
 
-/*GetEventsOK OK Response
+/*
+GetEventsOK OK Response
 
 swagger:response getEventsOK
 */
@@ -60,7 +61,8 @@ func (o *GetEventsOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // GetEventsNotFoundCode is the HTTP code returned for type GetEventsNotFound
 const GetEventsNotFoundCode int = 404
 
-/*GetEventsNotFound Entity Not Found
+/*
+GetEventsNotFound Entity Not Found
 
 swagger:response getEventsNotFound
 */

--- a/restapi/operations/resources/get_courses_for_resource.go
+++ b/restapi/operations/resources/get_courses_for_resource.go
@@ -29,10 +29,10 @@ func NewGetCoursesForResource(ctx *middleware.Context, handler GetCoursesForReso
 	return &GetCoursesForResource{Context: ctx, Handler: handler}
 }
 
-/* GetCoursesForResource swagger:route GET /resources/{id}/courses Resources getCoursesForResource
+/*
+	GetCoursesForResource swagger:route GET /resources/{id}/courses Resources getCoursesForResource
 
 Returns the courses for a resource
-
 */
 type GetCoursesForResource struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetCoursesForResource struct {
 func (o *GetCoursesForResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetCoursesForResourceParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetCoursesForResource) ServeHTTP(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/resources/get_courses_for_resource_responses.go
+++ b/restapi/operations/resources/get_courses_for_resource_responses.go
@@ -16,7 +16,8 @@ import (
 // GetCoursesForResourceOKCode is the HTTP code returned for type GetCoursesForResourceOK
 const GetCoursesForResourceOKCode int = 200
 
-/*GetCoursesForResourceOK OK Response
+/*
+GetCoursesForResourceOK OK Response
 
 swagger:response getCoursesForResourceOK
 */
@@ -60,7 +61,8 @@ func (o *GetCoursesForResourceOK) WriteResponse(rw http.ResponseWriter, producer
 // GetCoursesForResourceNotFoundCode is the HTTP code returned for type GetCoursesForResourceNotFound
 const GetCoursesForResourceNotFoundCode int = 404
 
-/*GetCoursesForResourceNotFound Entity Not Found
+/*
+GetCoursesForResourceNotFound Entity Not Found
 
 swagger:response getCoursesForResourceNotFound
 */

--- a/restapi/operations/resources/get_resource.go
+++ b/restapi/operations/resources/get_resource.go
@@ -29,10 +29,10 @@ func NewGetResource(ctx *middleware.Context, handler GetResourceHandler) *GetRes
 	return &GetResource{Context: ctx, Handler: handler}
 }
 
-/* GetResource swagger:route GET /resources/{id} Resources getResource
+/*
+	GetResource swagger:route GET /resources/{id} Resources getResource
 
 Returns a specific resource
-
 */
 type GetResource struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetResource struct {
 func (o *GetResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetResourceParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/resources/get_resource_responses.go
+++ b/restapi/operations/resources/get_resource_responses.go
@@ -16,7 +16,8 @@ import (
 // GetResourceOKCode is the HTTP code returned for type GetResourceOK
 const GetResourceOKCode int = 200
 
-/*GetResourceOK OK Response
+/*
+GetResourceOK OK Response
 
 swagger:response getResourceOK
 */
@@ -60,7 +61,8 @@ func (o *GetResourceOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // GetResourceNotFoundCode is the HTTP code returned for type GetResourceNotFound
 const GetResourceNotFoundCode int = 404
 
-/*GetResourceNotFound Entity Not Found
+/*
+GetResourceNotFound Entity Not Found
 
 swagger:response getResourceNotFound
 */

--- a/restapi/operations/resources/get_resources.go
+++ b/restapi/operations/resources/get_resources.go
@@ -29,10 +29,10 @@ func NewGetResources(ctx *middleware.Context, handler GetResourcesHandler) *GetR
 	return &GetResources{Context: ctx, Handler: handler}
 }
 
-/* GetResources swagger:route GET /resources Resources getResources
+/*
+	GetResources swagger:route GET /resources Resources getResources
 
 Returns a list of resources
-
 */
 type GetResources struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetResources struct {
 func (o *GetResources) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetResourcesParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetResources) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/resources/get_resources_responses.go
+++ b/restapi/operations/resources/get_resources_responses.go
@@ -16,7 +16,8 @@ import (
 // GetResourcesOKCode is the HTTP code returned for type GetResourcesOK
 const GetResourcesOKCode int = 200
 
-/*GetResourcesOK OK Response
+/*
+GetResourcesOK OK Response
 
 swagger:response getResourcesOK
 */

--- a/restapi/operations/resources/get_sections_for_resource.go
+++ b/restapi/operations/resources/get_sections_for_resource.go
@@ -29,10 +29,10 @@ func NewGetSectionsForResource(ctx *middleware.Context, handler GetSectionsForRe
 	return &GetSectionsForResource{Context: ctx, Handler: handler}
 }
 
-/* GetSectionsForResource swagger:route GET /resources/{id}/sections Resources getSectionsForResource
+/*
+	GetSectionsForResource swagger:route GET /resources/{id}/sections Resources getSectionsForResource
 
 Returns the sections for a resource
-
 */
 type GetSectionsForResource struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSectionsForResource struct {
 func (o *GetSectionsForResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSectionsForResourceParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSectionsForResource) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/resources/get_sections_for_resource_responses.go
+++ b/restapi/operations/resources/get_sections_for_resource_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSectionsForResourceOKCode is the HTTP code returned for type GetSectionsForResourceOK
 const GetSectionsForResourceOKCode int = 200
 
-/*GetSectionsForResourceOK OK Response
+/*
+GetSectionsForResourceOK OK Response
 
 swagger:response getSectionsForResourceOK
 */
@@ -60,7 +61,8 @@ func (o *GetSectionsForResourceOK) WriteResponse(rw http.ResponseWriter, produce
 // GetSectionsForResourceNotFoundCode is the HTTP code returned for type GetSectionsForResourceNotFound
 const GetSectionsForResourceNotFoundCode int = 404
 
-/*GetSectionsForResourceNotFound Entity Not Found
+/*
+GetSectionsForResourceNotFound Entity Not Found
 
 swagger:response getSectionsForResourceNotFound
 */

--- a/restapi/operations/resources/get_users_for_resource.go
+++ b/restapi/operations/resources/get_users_for_resource.go
@@ -29,10 +29,10 @@ func NewGetUsersForResource(ctx *middleware.Context, handler GetUsersForResource
 	return &GetUsersForResource{Context: ctx, Handler: handler}
 }
 
-/* GetUsersForResource swagger:route GET /resources/{id}/users Resources getUsersForResource
+/*
+	GetUsersForResource swagger:route GET /resources/{id}/users Resources getUsersForResource
 
 Returns the student and/or teacher users for a resource
-
 */
 type GetUsersForResource struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetUsersForResource struct {
 func (o *GetUsersForResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetUsersForResourceParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetUsersForResource) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/resources/get_users_for_resource_responses.go
+++ b/restapi/operations/resources/get_users_for_resource_responses.go
@@ -16,7 +16,8 @@ import (
 // GetUsersForResourceOKCode is the HTTP code returned for type GetUsersForResourceOK
 const GetUsersForResourceOKCode int = 200
 
-/*GetUsersForResourceOK OK Response
+/*
+GetUsersForResourceOK OK Response
 
 swagger:response getUsersForResourceOK
 */
@@ -60,7 +61,8 @@ func (o *GetUsersForResourceOK) WriteResponse(rw http.ResponseWriter, producer r
 // GetUsersForResourceNotFoundCode is the HTTP code returned for type GetUsersForResourceNotFound
 const GetUsersForResourceNotFoundCode int = 404
 
-/*GetUsersForResourceNotFound Entity Not Found
+/*
+GetUsersForResourceNotFound Entity Not Found
 
 swagger:response getUsersForResourceNotFound
 */

--- a/restapi/operations/schools/get_courses_for_school.go
+++ b/restapi/operations/schools/get_courses_for_school.go
@@ -29,10 +29,10 @@ func NewGetCoursesForSchool(ctx *middleware.Context, handler GetCoursesForSchool
 	return &GetCoursesForSchool{Context: ctx, Handler: handler}
 }
 
-/* GetCoursesForSchool swagger:route GET /schools/{id}/courses Schools getCoursesForSchool
+/*
+	GetCoursesForSchool swagger:route GET /schools/{id}/courses Schools getCoursesForSchool
 
 Returns the courses for a school
-
 */
 type GetCoursesForSchool struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetCoursesForSchool struct {
 func (o *GetCoursesForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetCoursesForSchoolParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetCoursesForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/schools/get_courses_for_school_responses.go
+++ b/restapi/operations/schools/get_courses_for_school_responses.go
@@ -16,7 +16,8 @@ import (
 // GetCoursesForSchoolOKCode is the HTTP code returned for type GetCoursesForSchoolOK
 const GetCoursesForSchoolOKCode int = 200
 
-/*GetCoursesForSchoolOK OK Response
+/*
+GetCoursesForSchoolOK OK Response
 
 swagger:response getCoursesForSchoolOK
 */
@@ -60,7 +61,8 @@ func (o *GetCoursesForSchoolOK) WriteResponse(rw http.ResponseWriter, producer r
 // GetCoursesForSchoolNotFoundCode is the HTTP code returned for type GetCoursesForSchoolNotFound
 const GetCoursesForSchoolNotFoundCode int = 404
 
-/*GetCoursesForSchoolNotFound Entity Not Found
+/*
+GetCoursesForSchoolNotFound Entity Not Found
 
 swagger:response getCoursesForSchoolNotFound
 */

--- a/restapi/operations/schools/get_district_for_school.go
+++ b/restapi/operations/schools/get_district_for_school.go
@@ -29,10 +29,10 @@ func NewGetDistrictForSchool(ctx *middleware.Context, handler GetDistrictForScho
 	return &GetDistrictForSchool{Context: ctx, Handler: handler}
 }
 
-/* GetDistrictForSchool swagger:route GET /schools/{id}/district Schools getDistrictForSchool
+/*
+	GetDistrictForSchool swagger:route GET /schools/{id}/district Schools getDistrictForSchool
 
 Returns the district for a school
-
 */
 type GetDistrictForSchool struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetDistrictForSchool struct {
 func (o *GetDistrictForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetDistrictForSchoolParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetDistrictForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/schools/get_district_for_school_responses.go
+++ b/restapi/operations/schools/get_district_for_school_responses.go
@@ -16,7 +16,8 @@ import (
 // GetDistrictForSchoolOKCode is the HTTP code returned for type GetDistrictForSchoolOK
 const GetDistrictForSchoolOKCode int = 200
 
-/*GetDistrictForSchoolOK OK Response
+/*
+GetDistrictForSchoolOK OK Response
 
 swagger:response getDistrictForSchoolOK
 */
@@ -60,7 +61,8 @@ func (o *GetDistrictForSchoolOK) WriteResponse(rw http.ResponseWriter, producer 
 // GetDistrictForSchoolNotFoundCode is the HTTP code returned for type GetDistrictForSchoolNotFound
 const GetDistrictForSchoolNotFoundCode int = 404
 
-/*GetDistrictForSchoolNotFound Entity Not Found
+/*
+GetDistrictForSchoolNotFound Entity Not Found
 
 swagger:response getDistrictForSchoolNotFound
 */

--- a/restapi/operations/schools/get_school.go
+++ b/restapi/operations/schools/get_school.go
@@ -29,10 +29,10 @@ func NewGetSchool(ctx *middleware.Context, handler GetSchoolHandler) *GetSchool 
 	return &GetSchool{Context: ctx, Handler: handler}
 }
 
-/* GetSchool swagger:route GET /schools/{id} Schools getSchool
+/*
+	GetSchool swagger:route GET /schools/{id} Schools getSchool
 
 Returns a specific school
-
 */
 type GetSchool struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSchool struct {
 func (o *GetSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSchoolParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/schools/get_school_responses.go
+++ b/restapi/operations/schools/get_school_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSchoolOKCode is the HTTP code returned for type GetSchoolOK
 const GetSchoolOKCode int = 200
 
-/*GetSchoolOK OK Response
+/*
+GetSchoolOK OK Response
 
 swagger:response getSchoolOK
 */
@@ -60,7 +61,8 @@ func (o *GetSchoolOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // GetSchoolNotFoundCode is the HTTP code returned for type GetSchoolNotFound
 const GetSchoolNotFoundCode int = 404
 
-/*GetSchoolNotFound Entity Not Found
+/*
+GetSchoolNotFound Entity Not Found
 
 swagger:response getSchoolNotFound
 */

--- a/restapi/operations/schools/get_schools.go
+++ b/restapi/operations/schools/get_schools.go
@@ -29,10 +29,10 @@ func NewGetSchools(ctx *middleware.Context, handler GetSchoolsHandler) *GetSchoo
 	return &GetSchools{Context: ctx, Handler: handler}
 }
 
-/* GetSchools swagger:route GET /schools Schools getSchools
+/*
+	GetSchools swagger:route GET /schools Schools getSchools
 
 Returns a list of schools
-
 */
 type GetSchools struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSchools struct {
 func (o *GetSchools) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSchoolsParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSchools) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/schools/get_schools_responses.go
+++ b/restapi/operations/schools/get_schools_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSchoolsOKCode is the HTTP code returned for type GetSchoolsOK
 const GetSchoolsOKCode int = 200
 
-/*GetSchoolsOK OK Response
+/*
+GetSchoolsOK OK Response
 
 swagger:response getSchoolsOK
 */

--- a/restapi/operations/schools/get_sections_for_school.go
+++ b/restapi/operations/schools/get_sections_for_school.go
@@ -29,10 +29,10 @@ func NewGetSectionsForSchool(ctx *middleware.Context, handler GetSectionsForScho
 	return &GetSectionsForSchool{Context: ctx, Handler: handler}
 }
 
-/* GetSectionsForSchool swagger:route GET /schools/{id}/sections Schools getSectionsForSchool
+/*
+	GetSectionsForSchool swagger:route GET /schools/{id}/sections Schools getSectionsForSchool
 
 Returns the sections for a school
-
 */
 type GetSectionsForSchool struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSectionsForSchool struct {
 func (o *GetSectionsForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSectionsForSchoolParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSectionsForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/schools/get_sections_for_school_responses.go
+++ b/restapi/operations/schools/get_sections_for_school_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSectionsForSchoolOKCode is the HTTP code returned for type GetSectionsForSchoolOK
 const GetSectionsForSchoolOKCode int = 200
 
-/*GetSectionsForSchoolOK OK Response
+/*
+GetSectionsForSchoolOK OK Response
 
 swagger:response getSectionsForSchoolOK
 */
@@ -60,7 +61,8 @@ func (o *GetSectionsForSchoolOK) WriteResponse(rw http.ResponseWriter, producer 
 // GetSectionsForSchoolNotFoundCode is the HTTP code returned for type GetSectionsForSchoolNotFound
 const GetSectionsForSchoolNotFoundCode int = 404
 
-/*GetSectionsForSchoolNotFound Entity Not Found
+/*
+GetSectionsForSchoolNotFound Entity Not Found
 
 swagger:response getSectionsForSchoolNotFound
 */

--- a/restapi/operations/schools/get_terms_for_school.go
+++ b/restapi/operations/schools/get_terms_for_school.go
@@ -29,10 +29,10 @@ func NewGetTermsForSchool(ctx *middleware.Context, handler GetTermsForSchoolHand
 	return &GetTermsForSchool{Context: ctx, Handler: handler}
 }
 
-/* GetTermsForSchool swagger:route GET /schools/{id}/terms Schools getTermsForSchool
+/*
+	GetTermsForSchool swagger:route GET /schools/{id}/terms Schools getTermsForSchool
 
 Returns the terms for a school
-
 */
 type GetTermsForSchool struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetTermsForSchool struct {
 func (o *GetTermsForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetTermsForSchoolParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetTermsForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/schools/get_terms_for_school_responses.go
+++ b/restapi/operations/schools/get_terms_for_school_responses.go
@@ -16,7 +16,8 @@ import (
 // GetTermsForSchoolOKCode is the HTTP code returned for type GetTermsForSchoolOK
 const GetTermsForSchoolOKCode int = 200
 
-/*GetTermsForSchoolOK OK Response
+/*
+GetTermsForSchoolOK OK Response
 
 swagger:response getTermsForSchoolOK
 */
@@ -60,7 +61,8 @@ func (o *GetTermsForSchoolOK) WriteResponse(rw http.ResponseWriter, producer run
 // GetTermsForSchoolNotFoundCode is the HTTP code returned for type GetTermsForSchoolNotFound
 const GetTermsForSchoolNotFoundCode int = 404
 
-/*GetTermsForSchoolNotFound Entity Not Found
+/*
+GetTermsForSchoolNotFound Entity Not Found
 
 swagger:response getTermsForSchoolNotFound
 */

--- a/restapi/operations/schools/get_users_for_school.go
+++ b/restapi/operations/schools/get_users_for_school.go
@@ -29,10 +29,10 @@ func NewGetUsersForSchool(ctx *middleware.Context, handler GetUsersForSchoolHand
 	return &GetUsersForSchool{Context: ctx, Handler: handler}
 }
 
-/* GetUsersForSchool swagger:route GET /schools/{id}/users Schools getUsersForSchool
+/*
+	GetUsersForSchool swagger:route GET /schools/{id}/users Schools getUsersForSchool
 
 Returns the staff, student, and/or teacher users for a school
-
 */
 type GetUsersForSchool struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetUsersForSchool struct {
 func (o *GetUsersForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetUsersForSchoolParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetUsersForSchool) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/schools/get_users_for_school_responses.go
+++ b/restapi/operations/schools/get_users_for_school_responses.go
@@ -16,7 +16,8 @@ import (
 // GetUsersForSchoolOKCode is the HTTP code returned for type GetUsersForSchoolOK
 const GetUsersForSchoolOKCode int = 200
 
-/*GetUsersForSchoolOK OK Response
+/*
+GetUsersForSchoolOK OK Response
 
 swagger:response getUsersForSchoolOK
 */
@@ -60,7 +61,8 @@ func (o *GetUsersForSchoolOK) WriteResponse(rw http.ResponseWriter, producer run
 // GetUsersForSchoolNotFoundCode is the HTTP code returned for type GetUsersForSchoolNotFound
 const GetUsersForSchoolNotFoundCode int = 404
 
-/*GetUsersForSchoolNotFound Entity Not Found
+/*
+GetUsersForSchoolNotFound Entity Not Found
 
 swagger:response getUsersForSchoolNotFound
 */

--- a/restapi/operations/sections/get_course_for_section.go
+++ b/restapi/operations/sections/get_course_for_section.go
@@ -29,10 +29,10 @@ func NewGetCourseForSection(ctx *middleware.Context, handler GetCourseForSection
 	return &GetCourseForSection{Context: ctx, Handler: handler}
 }
 
-/* GetCourseForSection swagger:route GET /sections/{id}/course Sections getCourseForSection
+/*
+	GetCourseForSection swagger:route GET /sections/{id}/course Sections getCourseForSection
 
 Returns the course for a section
-
 */
 type GetCourseForSection struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetCourseForSection struct {
 func (o *GetCourseForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetCourseForSectionParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetCourseForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_course_for_section_responses.go
+++ b/restapi/operations/sections/get_course_for_section_responses.go
@@ -16,7 +16,8 @@ import (
 // GetCourseForSectionOKCode is the HTTP code returned for type GetCourseForSectionOK
 const GetCourseForSectionOKCode int = 200
 
-/*GetCourseForSectionOK OK Response
+/*
+GetCourseForSectionOK OK Response
 
 swagger:response getCourseForSectionOK
 */
@@ -60,7 +61,8 @@ func (o *GetCourseForSectionOK) WriteResponse(rw http.ResponseWriter, producer r
 // GetCourseForSectionNotFoundCode is the HTTP code returned for type GetCourseForSectionNotFound
 const GetCourseForSectionNotFoundCode int = 404
 
-/*GetCourseForSectionNotFound Entity Not Found
+/*
+GetCourseForSectionNotFound Entity Not Found
 
 swagger:response getCourseForSectionNotFound
 */

--- a/restapi/operations/sections/get_district_for_section.go
+++ b/restapi/operations/sections/get_district_for_section.go
@@ -29,10 +29,10 @@ func NewGetDistrictForSection(ctx *middleware.Context, handler GetDistrictForSec
 	return &GetDistrictForSection{Context: ctx, Handler: handler}
 }
 
-/* GetDistrictForSection swagger:route GET /sections/{id}/district Sections getDistrictForSection
+/*
+	GetDistrictForSection swagger:route GET /sections/{id}/district Sections getDistrictForSection
 
 Returns the district for a section
-
 */
 type GetDistrictForSection struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetDistrictForSection struct {
 func (o *GetDistrictForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetDistrictForSectionParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetDistrictForSection) ServeHTTP(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_district_for_section_responses.go
+++ b/restapi/operations/sections/get_district_for_section_responses.go
@@ -16,7 +16,8 @@ import (
 // GetDistrictForSectionOKCode is the HTTP code returned for type GetDistrictForSectionOK
 const GetDistrictForSectionOKCode int = 200
 
-/*GetDistrictForSectionOK OK Response
+/*
+GetDistrictForSectionOK OK Response
 
 swagger:response getDistrictForSectionOK
 */
@@ -60,7 +61,8 @@ func (o *GetDistrictForSectionOK) WriteResponse(rw http.ResponseWriter, producer
 // GetDistrictForSectionNotFoundCode is the HTTP code returned for type GetDistrictForSectionNotFound
 const GetDistrictForSectionNotFoundCode int = 404
 
-/*GetDistrictForSectionNotFound Entity Not Found
+/*
+GetDistrictForSectionNotFound Entity Not Found
 
 swagger:response getDistrictForSectionNotFound
 */

--- a/restapi/operations/sections/get_resources_for_section.go
+++ b/restapi/operations/sections/get_resources_for_section.go
@@ -29,10 +29,10 @@ func NewGetResourcesForSection(ctx *middleware.Context, handler GetResourcesForS
 	return &GetResourcesForSection{Context: ctx, Handler: handler}
 }
 
-/* GetResourcesForSection swagger:route GET /sections/{id}/resources Sections getResourcesForSection
+/*
+	GetResourcesForSection swagger:route GET /sections/{id}/resources Sections getResourcesForSection
 
 Returns the resources for a section
-
 */
 type GetResourcesForSection struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetResourcesForSection struct {
 func (o *GetResourcesForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetResourcesForSectionParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetResourcesForSection) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_resources_for_section_responses.go
+++ b/restapi/operations/sections/get_resources_for_section_responses.go
@@ -16,7 +16,8 @@ import (
 // GetResourcesForSectionOKCode is the HTTP code returned for type GetResourcesForSectionOK
 const GetResourcesForSectionOKCode int = 200
 
-/*GetResourcesForSectionOK OK Response
+/*
+GetResourcesForSectionOK OK Response
 
 swagger:response getResourcesForSectionOK
 */
@@ -60,7 +61,8 @@ func (o *GetResourcesForSectionOK) WriteResponse(rw http.ResponseWriter, produce
 // GetResourcesForSectionNotFoundCode is the HTTP code returned for type GetResourcesForSectionNotFound
 const GetResourcesForSectionNotFoundCode int = 404
 
-/*GetResourcesForSectionNotFound Entity Not Found
+/*
+GetResourcesForSectionNotFound Entity Not Found
 
 swagger:response getResourcesForSectionNotFound
 */

--- a/restapi/operations/sections/get_school_for_section.go
+++ b/restapi/operations/sections/get_school_for_section.go
@@ -29,10 +29,10 @@ func NewGetSchoolForSection(ctx *middleware.Context, handler GetSchoolForSection
 	return &GetSchoolForSection{Context: ctx, Handler: handler}
 }
 
-/* GetSchoolForSection swagger:route GET /sections/{id}/school Sections getSchoolForSection
+/*
+	GetSchoolForSection swagger:route GET /sections/{id}/school Sections getSchoolForSection
 
 Returns the school for a section
-
 */
 type GetSchoolForSection struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSchoolForSection struct {
 func (o *GetSchoolForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSchoolForSectionParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSchoolForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_school_for_section_responses.go
+++ b/restapi/operations/sections/get_school_for_section_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSchoolForSectionOKCode is the HTTP code returned for type GetSchoolForSectionOK
 const GetSchoolForSectionOKCode int = 200
 
-/*GetSchoolForSectionOK OK Response
+/*
+GetSchoolForSectionOK OK Response
 
 swagger:response getSchoolForSectionOK
 */
@@ -60,7 +61,8 @@ func (o *GetSchoolForSectionOK) WriteResponse(rw http.ResponseWriter, producer r
 // GetSchoolForSectionNotFoundCode is the HTTP code returned for type GetSchoolForSectionNotFound
 const GetSchoolForSectionNotFoundCode int = 404
 
-/*GetSchoolForSectionNotFound Entity Not Found
+/*
+GetSchoolForSectionNotFound Entity Not Found
 
 swagger:response getSchoolForSectionNotFound
 */

--- a/restapi/operations/sections/get_section.go
+++ b/restapi/operations/sections/get_section.go
@@ -29,10 +29,10 @@ func NewGetSection(ctx *middleware.Context, handler GetSectionHandler) *GetSecti
 	return &GetSection{Context: ctx, Handler: handler}
 }
 
-/* GetSection swagger:route GET /sections/{id} Sections getSection
+/*
+	GetSection swagger:route GET /sections/{id} Sections getSection
 
 Returns a specific section
-
 */
 type GetSection struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSection struct {
 func (o *GetSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSectionParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_section_responses.go
+++ b/restapi/operations/sections/get_section_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSectionOKCode is the HTTP code returned for type GetSectionOK
 const GetSectionOKCode int = 200
 
-/*GetSectionOK OK Response
+/*
+GetSectionOK OK Response
 
 swagger:response getSectionOK
 */
@@ -60,7 +61,8 @@ func (o *GetSectionOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // GetSectionNotFoundCode is the HTTP code returned for type GetSectionNotFound
 const GetSectionNotFoundCode int = 404
 
-/*GetSectionNotFound Entity Not Found
+/*
+GetSectionNotFound Entity Not Found
 
 swagger:response getSectionNotFound
 */

--- a/restapi/operations/sections/get_sections.go
+++ b/restapi/operations/sections/get_sections.go
@@ -29,10 +29,10 @@ func NewGetSections(ctx *middleware.Context, handler GetSectionsHandler) *GetSec
 	return &GetSections{Context: ctx, Handler: handler}
 }
 
-/* GetSections swagger:route GET /sections Sections getSections
+/*
+	GetSections swagger:route GET /sections Sections getSections
 
 Returns a list of sections
-
 */
 type GetSections struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSections struct {
 func (o *GetSections) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSectionsParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSections) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_sections_responses.go
+++ b/restapi/operations/sections/get_sections_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSectionsOKCode is the HTTP code returned for type GetSectionsOK
 const GetSectionsOKCode int = 200
 
-/*GetSectionsOK OK Response
+/*
+GetSectionsOK OK Response
 
 swagger:response getSectionsOK
 */

--- a/restapi/operations/sections/get_term_for_section.go
+++ b/restapi/operations/sections/get_term_for_section.go
@@ -29,10 +29,10 @@ func NewGetTermForSection(ctx *middleware.Context, handler GetTermForSectionHand
 	return &GetTermForSection{Context: ctx, Handler: handler}
 }
 
-/* GetTermForSection swagger:route GET /sections/{id}/term Sections getTermForSection
+/*
+	GetTermForSection swagger:route GET /sections/{id}/term Sections getTermForSection
 
 Returns the term for a section
-
 */
 type GetTermForSection struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetTermForSection struct {
 func (o *GetTermForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetTermForSectionParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetTermForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_term_for_section_responses.go
+++ b/restapi/operations/sections/get_term_for_section_responses.go
@@ -16,7 +16,8 @@ import (
 // GetTermForSectionOKCode is the HTTP code returned for type GetTermForSectionOK
 const GetTermForSectionOKCode int = 200
 
-/*GetTermForSectionOK OK Response
+/*
+GetTermForSectionOK OK Response
 
 swagger:response getTermForSectionOK
 */
@@ -60,7 +61,8 @@ func (o *GetTermForSectionOK) WriteResponse(rw http.ResponseWriter, producer run
 // GetTermForSectionNotFoundCode is the HTTP code returned for type GetTermForSectionNotFound
 const GetTermForSectionNotFoundCode int = 404
 
-/*GetTermForSectionNotFound Entity Not Found
+/*
+GetTermForSectionNotFound Entity Not Found
 
 swagger:response getTermForSectionNotFound
 */

--- a/restapi/operations/sections/get_users_for_section.go
+++ b/restapi/operations/sections/get_users_for_section.go
@@ -29,10 +29,10 @@ func NewGetUsersForSection(ctx *middleware.Context, handler GetUsersForSectionHa
 	return &GetUsersForSection{Context: ctx, Handler: handler}
 }
 
-/* GetUsersForSection swagger:route GET /sections/{id}/users Sections getUsersForSection
+/*
+	GetUsersForSection swagger:route GET /sections/{id}/users Sections getUsersForSection
 
 Returns the student and/or teacher users for a section
-
 */
 type GetUsersForSection struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetUsersForSection struct {
 func (o *GetUsersForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetUsersForSectionParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetUsersForSection) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/sections/get_users_for_section_responses.go
+++ b/restapi/operations/sections/get_users_for_section_responses.go
@@ -16,7 +16,8 @@ import (
 // GetUsersForSectionOKCode is the HTTP code returned for type GetUsersForSectionOK
 const GetUsersForSectionOKCode int = 200
 
-/*GetUsersForSectionOK OK Response
+/*
+GetUsersForSectionOK OK Response
 
 swagger:response getUsersForSectionOK
 */
@@ -60,7 +61,8 @@ func (o *GetUsersForSectionOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetUsersForSectionNotFoundCode is the HTTP code returned for type GetUsersForSectionNotFound
 const GetUsersForSectionNotFoundCode int = 404
 
-/*GetUsersForSectionNotFound Entity Not Found
+/*
+GetUsersForSectionNotFound Entity Not Found
 
 swagger:response getUsersForSectionNotFound
 */

--- a/restapi/operations/terms/get_district_for_term.go
+++ b/restapi/operations/terms/get_district_for_term.go
@@ -29,10 +29,10 @@ func NewGetDistrictForTerm(ctx *middleware.Context, handler GetDistrictForTermHa
 	return &GetDistrictForTerm{Context: ctx, Handler: handler}
 }
 
-/* GetDistrictForTerm swagger:route GET /terms/{id}/district Terms getDistrictForTerm
+/*
+	GetDistrictForTerm swagger:route GET /terms/{id}/district Terms getDistrictForTerm
 
 Returns the district for a term
-
 */
 type GetDistrictForTerm struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetDistrictForTerm struct {
 func (o *GetDistrictForTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetDistrictForTermParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetDistrictForTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/terms/get_district_for_term_responses.go
+++ b/restapi/operations/terms/get_district_for_term_responses.go
@@ -16,7 +16,8 @@ import (
 // GetDistrictForTermOKCode is the HTTP code returned for type GetDistrictForTermOK
 const GetDistrictForTermOKCode int = 200
 
-/*GetDistrictForTermOK OK Response
+/*
+GetDistrictForTermOK OK Response
 
 swagger:response getDistrictForTermOK
 */
@@ -60,7 +61,8 @@ func (o *GetDistrictForTermOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetDistrictForTermNotFoundCode is the HTTP code returned for type GetDistrictForTermNotFound
 const GetDistrictForTermNotFoundCode int = 404
 
-/*GetDistrictForTermNotFound Entity Not Found
+/*
+GetDistrictForTermNotFound Entity Not Found
 
 swagger:response getDistrictForTermNotFound
 */

--- a/restapi/operations/terms/get_schools_for_term.go
+++ b/restapi/operations/terms/get_schools_for_term.go
@@ -29,10 +29,10 @@ func NewGetSchoolsForTerm(ctx *middleware.Context, handler GetSchoolsForTermHand
 	return &GetSchoolsForTerm{Context: ctx, Handler: handler}
 }
 
-/* GetSchoolsForTerm swagger:route GET /terms/{id}/schools Terms getSchoolsForTerm
+/*
+	GetSchoolsForTerm swagger:route GET /terms/{id}/schools Terms getSchoolsForTerm
 
 Returns the schools for a term
-
 */
 type GetSchoolsForTerm struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSchoolsForTerm struct {
 func (o *GetSchoolsForTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSchoolsForTermParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSchoolsForTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/terms/get_schools_for_term_responses.go
+++ b/restapi/operations/terms/get_schools_for_term_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSchoolsForTermOKCode is the HTTP code returned for type GetSchoolsForTermOK
 const GetSchoolsForTermOKCode int = 200
 
-/*GetSchoolsForTermOK OK Response
+/*
+GetSchoolsForTermOK OK Response
 
 swagger:response getSchoolsForTermOK
 */
@@ -60,7 +61,8 @@ func (o *GetSchoolsForTermOK) WriteResponse(rw http.ResponseWriter, producer run
 // GetSchoolsForTermNotFoundCode is the HTTP code returned for type GetSchoolsForTermNotFound
 const GetSchoolsForTermNotFoundCode int = 404
 
-/*GetSchoolsForTermNotFound Entity Not Found
+/*
+GetSchoolsForTermNotFound Entity Not Found
 
 swagger:response getSchoolsForTermNotFound
 */

--- a/restapi/operations/terms/get_sections_for_term.go
+++ b/restapi/operations/terms/get_sections_for_term.go
@@ -29,10 +29,10 @@ func NewGetSectionsForTerm(ctx *middleware.Context, handler GetSectionsForTermHa
 	return &GetSectionsForTerm{Context: ctx, Handler: handler}
 }
 
-/* GetSectionsForTerm swagger:route GET /terms/{id}/sections Terms getSectionsForTerm
+/*
+	GetSectionsForTerm swagger:route GET /terms/{id}/sections Terms getSectionsForTerm
 
 Returns the sections for a term
-
 */
 type GetSectionsForTerm struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSectionsForTerm struct {
 func (o *GetSectionsForTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSectionsForTermParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSectionsForTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/terms/get_sections_for_term_responses.go
+++ b/restapi/operations/terms/get_sections_for_term_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSectionsForTermOKCode is the HTTP code returned for type GetSectionsForTermOK
 const GetSectionsForTermOKCode int = 200
 
-/*GetSectionsForTermOK OK Response
+/*
+GetSectionsForTermOK OK Response
 
 swagger:response getSectionsForTermOK
 */
@@ -60,7 +61,8 @@ func (o *GetSectionsForTermOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetSectionsForTermNotFoundCode is the HTTP code returned for type GetSectionsForTermNotFound
 const GetSectionsForTermNotFoundCode int = 404
 
-/*GetSectionsForTermNotFound Entity Not Found
+/*
+GetSectionsForTermNotFound Entity Not Found
 
 swagger:response getSectionsForTermNotFound
 */

--- a/restapi/operations/terms/get_term.go
+++ b/restapi/operations/terms/get_term.go
@@ -29,10 +29,10 @@ func NewGetTerm(ctx *middleware.Context, handler GetTermHandler) *GetTerm {
 	return &GetTerm{Context: ctx, Handler: handler}
 }
 
-/* GetTerm swagger:route GET /terms/{id} Terms getTerm
+/*
+	GetTerm swagger:route GET /terms/{id} Terms getTerm
 
 Returns a specific term
-
 */
 type GetTerm struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetTerm struct {
 func (o *GetTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetTermParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetTerm) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/terms/get_term_responses.go
+++ b/restapi/operations/terms/get_term_responses.go
@@ -16,7 +16,8 @@ import (
 // GetTermOKCode is the HTTP code returned for type GetTermOK
 const GetTermOKCode int = 200
 
-/*GetTermOK OK Response
+/*
+GetTermOK OK Response
 
 swagger:response getTermOK
 */
@@ -60,7 +61,8 @@ func (o *GetTermOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 // GetTermNotFoundCode is the HTTP code returned for type GetTermNotFound
 const GetTermNotFoundCode int = 404
 
-/*GetTermNotFound Entity Not Found
+/*
+GetTermNotFound Entity Not Found
 
 swagger:response getTermNotFound
 */

--- a/restapi/operations/terms/get_terms.go
+++ b/restapi/operations/terms/get_terms.go
@@ -29,10 +29,10 @@ func NewGetTerms(ctx *middleware.Context, handler GetTermsHandler) *GetTerms {
 	return &GetTerms{Context: ctx, Handler: handler}
 }
 
-/* GetTerms swagger:route GET /terms Terms getTerms
+/*
+	GetTerms swagger:route GET /terms Terms getTerms
 
 Returns a list of terms
-
 */
 type GetTerms struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetTerms struct {
 func (o *GetTerms) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetTermsParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetTerms) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/terms/get_terms_responses.go
+++ b/restapi/operations/terms/get_terms_responses.go
@@ -16,7 +16,8 @@ import (
 // GetTermsOKCode is the HTTP code returned for type GetTermsOK
 const GetTermsOKCode int = 200
 
-/*GetTermsOK OK Response
+/*
+GetTermsOK OK Response
 
 swagger:response getTermsOK
 */

--- a/restapi/operations/users/get_contacts_for_user.go
+++ b/restapi/operations/users/get_contacts_for_user.go
@@ -29,10 +29,10 @@ func NewGetContactsForUser(ctx *middleware.Context, handler GetContactsForUserHa
 	return &GetContactsForUser{Context: ctx, Handler: handler}
 }
 
-/* GetContactsForUser swagger:route GET /users/{id}/mycontacts Users getContactsForUser
+/*
+	GetContactsForUser swagger:route GET /users/{id}/mycontacts Users getContactsForUser
 
 Returns the contact users for a student user
-
 */
 type GetContactsForUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetContactsForUser struct {
 func (o *GetContactsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetContactsForUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetContactsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_contacts_for_user_responses.go
+++ b/restapi/operations/users/get_contacts_for_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetContactsForUserOKCode is the HTTP code returned for type GetContactsForUserOK
 const GetContactsForUserOKCode int = 200
 
-/*GetContactsForUserOK OK Response
+/*
+GetContactsForUserOK OK Response
 
 swagger:response getContactsForUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetContactsForUserOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetContactsForUserNotFoundCode is the HTTP code returned for type GetContactsForUserNotFound
 const GetContactsForUserNotFoundCode int = 404
 
-/*GetContactsForUserNotFound Entity Not Found
+/*
+GetContactsForUserNotFound Entity Not Found
 
 swagger:response getContactsForUserNotFound
 */

--- a/restapi/operations/users/get_district_for_user.go
+++ b/restapi/operations/users/get_district_for_user.go
@@ -29,10 +29,10 @@ func NewGetDistrictForUser(ctx *middleware.Context, handler GetDistrictForUserHa
 	return &GetDistrictForUser{Context: ctx, Handler: handler}
 }
 
-/* GetDistrictForUser swagger:route GET /users/{id}/district Users getDistrictForUser
+/*
+	GetDistrictForUser swagger:route GET /users/{id}/district Users getDistrictForUser
 
 Returns the district for a user
-
 */
 type GetDistrictForUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetDistrictForUser struct {
 func (o *GetDistrictForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetDistrictForUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetDistrictForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_district_for_user_responses.go
+++ b/restapi/operations/users/get_district_for_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetDistrictForUserOKCode is the HTTP code returned for type GetDistrictForUserOK
 const GetDistrictForUserOKCode int = 200
 
-/*GetDistrictForUserOK OK Response
+/*
+GetDistrictForUserOK OK Response
 
 swagger:response getDistrictForUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetDistrictForUserOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetDistrictForUserNotFoundCode is the HTTP code returned for type GetDistrictForUserNotFound
 const GetDistrictForUserNotFoundCode int = 404
 
-/*GetDistrictForUserNotFound Entity Not Found
+/*
+GetDistrictForUserNotFound Entity Not Found
 
 swagger:response getDistrictForUserNotFound
 */

--- a/restapi/operations/users/get_resources_for_user.go
+++ b/restapi/operations/users/get_resources_for_user.go
@@ -29,10 +29,10 @@ func NewGetResourcesForUser(ctx *middleware.Context, handler GetResourcesForUser
 	return &GetResourcesForUser{Context: ctx, Handler: handler}
 }
 
-/* GetResourcesForUser swagger:route GET /users/{id}/resources Users getResourcesForUser
+/*
+	GetResourcesForUser swagger:route GET /users/{id}/resources Users getResourcesForUser
 
 Returns the resources for a user
-
 */
 type GetResourcesForUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetResourcesForUser struct {
 func (o *GetResourcesForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetResourcesForUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetResourcesForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_resources_for_user_responses.go
+++ b/restapi/operations/users/get_resources_for_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetResourcesForUserOKCode is the HTTP code returned for type GetResourcesForUserOK
 const GetResourcesForUserOKCode int = 200
 
-/*GetResourcesForUserOK OK Response
+/*
+GetResourcesForUserOK OK Response
 
 swagger:response getResourcesForUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetResourcesForUserOK) WriteResponse(rw http.ResponseWriter, producer r
 // GetResourcesForUserNotFoundCode is the HTTP code returned for type GetResourcesForUserNotFound
 const GetResourcesForUserNotFoundCode int = 404
 
-/*GetResourcesForUserNotFound Entity Not Found
+/*
+GetResourcesForUserNotFound Entity Not Found
 
 swagger:response getResourcesForUserNotFound
 */

--- a/restapi/operations/users/get_schools_for_user.go
+++ b/restapi/operations/users/get_schools_for_user.go
@@ -29,10 +29,10 @@ func NewGetSchoolsForUser(ctx *middleware.Context, handler GetSchoolsForUserHand
 	return &GetSchoolsForUser{Context: ctx, Handler: handler}
 }
 
-/* GetSchoolsForUser swagger:route GET /users/{id}/schools Users getSchoolsForUser
+/*
+	GetSchoolsForUser swagger:route GET /users/{id}/schools Users getSchoolsForUser
 
 Returns the schools for a user
-
 */
 type GetSchoolsForUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSchoolsForUser struct {
 func (o *GetSchoolsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSchoolsForUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSchoolsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_schools_for_user_responses.go
+++ b/restapi/operations/users/get_schools_for_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSchoolsForUserOKCode is the HTTP code returned for type GetSchoolsForUserOK
 const GetSchoolsForUserOKCode int = 200
 
-/*GetSchoolsForUserOK OK Response
+/*
+GetSchoolsForUserOK OK Response
 
 swagger:response getSchoolsForUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetSchoolsForUserOK) WriteResponse(rw http.ResponseWriter, producer run
 // GetSchoolsForUserNotFoundCode is the HTTP code returned for type GetSchoolsForUserNotFound
 const GetSchoolsForUserNotFoundCode int = 404
 
-/*GetSchoolsForUserNotFound Entity Not Found
+/*
+GetSchoolsForUserNotFound Entity Not Found
 
 swagger:response getSchoolsForUserNotFound
 */

--- a/restapi/operations/users/get_sections_for_user.go
+++ b/restapi/operations/users/get_sections_for_user.go
@@ -29,10 +29,10 @@ func NewGetSectionsForUser(ctx *middleware.Context, handler GetSectionsForUserHa
 	return &GetSectionsForUser{Context: ctx, Handler: handler}
 }
 
-/* GetSectionsForUser swagger:route GET /users/{id}/sections Users getSectionsForUser
+/*
+	GetSectionsForUser swagger:route GET /users/{id}/sections Users getSectionsForUser
 
 Returns the sections for a user
-
 */
 type GetSectionsForUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetSectionsForUser struct {
 func (o *GetSectionsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetSectionsForUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetSectionsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_sections_for_user_responses.go
+++ b/restapi/operations/users/get_sections_for_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetSectionsForUserOKCode is the HTTP code returned for type GetSectionsForUserOK
 const GetSectionsForUserOKCode int = 200
 
-/*GetSectionsForUserOK OK Response
+/*
+GetSectionsForUserOK OK Response
 
 swagger:response getSectionsForUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetSectionsForUserOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetSectionsForUserNotFoundCode is the HTTP code returned for type GetSectionsForUserNotFound
 const GetSectionsForUserNotFoundCode int = 404
 
-/*GetSectionsForUserNotFound Entity Not Found
+/*
+GetSectionsForUserNotFound Entity Not Found
 
 swagger:response getSectionsForUserNotFound
 */

--- a/restapi/operations/users/get_students_for_user.go
+++ b/restapi/operations/users/get_students_for_user.go
@@ -29,10 +29,10 @@ func NewGetStudentsForUser(ctx *middleware.Context, handler GetStudentsForUserHa
 	return &GetStudentsForUser{Context: ctx, Handler: handler}
 }
 
-/* GetStudentsForUser swagger:route GET /users/{id}/mystudents Users getStudentsForUser
+/*
+	GetStudentsForUser swagger:route GET /users/{id}/mystudents Users getStudentsForUser
 
 Returns the student users for a teacher or contact user
-
 */
 type GetStudentsForUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetStudentsForUser struct {
 func (o *GetStudentsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetStudentsForUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetStudentsForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_students_for_user_responses.go
+++ b/restapi/operations/users/get_students_for_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetStudentsForUserOKCode is the HTTP code returned for type GetStudentsForUserOK
 const GetStudentsForUserOKCode int = 200
 
-/*GetStudentsForUserOK OK Response
+/*
+GetStudentsForUserOK OK Response
 
 swagger:response getStudentsForUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetStudentsForUserOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetStudentsForUserNotFoundCode is the HTTP code returned for type GetStudentsForUserNotFound
 const GetStudentsForUserNotFoundCode int = 404
 
-/*GetStudentsForUserNotFound Entity Not Found
+/*
+GetStudentsForUserNotFound Entity Not Found
 
 swagger:response getStudentsForUserNotFound
 */

--- a/restapi/operations/users/get_teachers_for_user.go
+++ b/restapi/operations/users/get_teachers_for_user.go
@@ -29,10 +29,10 @@ func NewGetTeachersForUser(ctx *middleware.Context, handler GetTeachersForUserHa
 	return &GetTeachersForUser{Context: ctx, Handler: handler}
 }
 
-/* GetTeachersForUser swagger:route GET /users/{id}/myteachers Users getTeachersForUser
+/*
+	GetTeachersForUser swagger:route GET /users/{id}/myteachers Users getTeachersForUser
 
 Returns the teacher users for a student user
-
 */
 type GetTeachersForUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetTeachersForUser struct {
 func (o *GetTeachersForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetTeachersForUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetTeachersForUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_teachers_for_user_responses.go
+++ b/restapi/operations/users/get_teachers_for_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetTeachersForUserOKCode is the HTTP code returned for type GetTeachersForUserOK
 const GetTeachersForUserOKCode int = 200
 
-/*GetTeachersForUserOK OK Response
+/*
+GetTeachersForUserOK OK Response
 
 swagger:response getTeachersForUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetTeachersForUserOK) WriteResponse(rw http.ResponseWriter, producer ru
 // GetTeachersForUserNotFoundCode is the HTTP code returned for type GetTeachersForUserNotFound
 const GetTeachersForUserNotFoundCode int = 404
 
-/*GetTeachersForUserNotFound Entity Not Found
+/*
+GetTeachersForUserNotFound Entity Not Found
 
 swagger:response getTeachersForUserNotFound
 */

--- a/restapi/operations/users/get_user.go
+++ b/restapi/operations/users/get_user.go
@@ -29,10 +29,10 @@ func NewGetUser(ctx *middleware.Context, handler GetUserHandler) *GetUser {
 	return &GetUser{Context: ctx, Handler: handler}
 }
 
-/* GetUser swagger:route GET /users/{id} Users getUser
+/*
+	GetUser swagger:route GET /users/{id} Users getUser
 
 Returns a specific user
-
 */
 type GetUser struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetUser struct {
 func (o *GetUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_user_responses.go
+++ b/restapi/operations/users/get_user_responses.go
@@ -16,7 +16,8 @@ import (
 // GetUserOKCode is the HTTP code returned for type GetUserOK
 const GetUserOKCode int = 200
 
-/*GetUserOK OK Response
+/*
+GetUserOK OK Response
 
 swagger:response getUserOK
 */
@@ -60,7 +61,8 @@ func (o *GetUserOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 // GetUserNotFoundCode is the HTTP code returned for type GetUserNotFound
 const GetUserNotFoundCode int = 404
 
-/*GetUserNotFound Entity Not Found
+/*
+GetUserNotFound Entity Not Found
 
 swagger:response getUserNotFound
 */

--- a/restapi/operations/users/get_users.go
+++ b/restapi/operations/users/get_users.go
@@ -29,10 +29,10 @@ func NewGetUsers(ctx *middleware.Context, handler GetUsersHandler) *GetUsers {
 	return &GetUsers{Context: ctx, Handler: handler}
 }
 
-/* GetUsers swagger:route GET /users Users getUsers
+/*
+	GetUsers swagger:route GET /users Users getUsers
 
 Returns a list of contact, district admin, staff, student, and/or teacher users
-
 */
 type GetUsers struct {
 	Context *middleware.Context
@@ -42,7 +42,7 @@ type GetUsers struct {
 func (o *GetUsers) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetUsersParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
@@ -51,7 +51,7 @@ func (o *GetUsers) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if aCtx != nil {
-		r = aCtx
+		*r = *aCtx
 	}
 	var principal interface{}
 	if uprinc != nil {

--- a/restapi/operations/users/get_users_responses.go
+++ b/restapi/operations/users/get_users_responses.go
@@ -16,7 +16,8 @@ import (
 // GetUsersOKCode is the HTTP code returned for type GetUsersOK
 const GetUsersOKCode int = 200
 
-/*GetUsersOK OK Response
+/*
+GetUsersOK OK Response
 
 swagger:response getUsersOK
 */

--- a/restapi/server.go
+++ b/restapi/server.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -274,7 +273,7 @@ func (s *Server) Serve() (err error) {
 
 		if s.TLSCACertificate != "" {
 			// include specified CA certificate
-			caCert, caCertErr := ioutil.ReadFile(string(s.TLSCACertificate))
+			caCert, caCertErr := os.ReadFile(string(s.TLSCACertificate))
 			if caCertErr != nil {
 				return caCertErr
 			}
@@ -304,9 +303,6 @@ func (s *Server) Serve() (err error) {
 			// this happens with a wrong custom TLS configurator
 			s.Fatalf("no certificate was configured for TLS")
 		}
-
-		// must have at least one certificate or panics
-		httpsServer.TLSConfig.BuildNameToCertificate()
 
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: Data API
   description: Serves the Clever Data API
-  version: 3.0.0
+  version: 3.0.1
 schemes:
   - https
 produces:
@@ -1573,6 +1573,9 @@ definitions:
         type: string
         x-validation: true
         x-nullable: true
+      course_name:
+        type: string
+        x-nullable: true
       created:
         type: string
         format: datetime
@@ -1658,6 +1661,9 @@ definitions:
       term_id:
         type: string
         x-validation: true
+        x-nullable: true
+      term_name:
+        type: string
         x-nullable: true
       ext:
         type: object


### PR DESCRIPTION
This is a little messy since these fields aren't actually returned by this API when getting sections :P 

But basically we use this swagger definition when ingesting for GCRi and we need these fields for templating purposes. We _could_ write a wrapper struct with all these fields + the 2 new ones that we save & template on, or we could update this with the fields we're going to use. :) 

A ton of autogen code changed when I ran `make generate`, probably bc swagger changed in some way.